### PR TITLE
Rollback table with images to HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,32 @@
 
 Custom [HACS] plugin that allows you to rearrange, hide, and add menu items to [Home Assistant]'s sidebar.
 
-| Default sidebar | Hide some items | Add new items | Reorder items |
-| --------------- | --------------- | ------------- | ------------- |
-| ![default sidebar](/images/default-sidebar.png) | ![default sidebar](/images/hide-items.png) | ![default sidebar](/images/new-items.png) | ![default sidebar](/images/reorder-items.png) |
+<table>
+  <thead>
+    <tr>
+      <th width="25%">Default sidebar</th>
+      <th width="25%">Hide some items</th>
+      <th width="25%">Add new items</th>
+      <th width="25%">Reorder items</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <img src="https://raw.githubusercontent.com/elchininet/custom-sidebar/master/images/default-sidebar.png" alt="default sidebar" />
+      </td>
+      <td>
+        <img src="https://raw.githubusercontent.com/elchininet/custom-sidebar/master/images/hide-items.png" alt="hide items" />
+      </td>
+      <td>
+        <img src="https://raw.githubusercontent.com/elchininet/custom-sidebar/master/images/new-items.png" alt="new items" />
+      </td>
+      <td>
+        <img src="https://raw.githubusercontent.com/elchininet/custom-sidebar/master/images/reorder-items.png" alt="reorder items" />
+      </td>
+    </tr>
+  </tbody>
+</table>
 
 This is a refactor of [custom-sidebar-v2] by @galloween, which unfortunatelly is now unmaintained and archived. In its beginning, @galloween's code was a refactor of the [original Custom Sidebar] plugin by @Villhellm (R.I.P.). This version refactored completely @galloween's code, using [home-assistant-query-selector] to make it less likely to break with future Home Assistant front-end updates.
 


### PR DESCRIPTION
This pull request changes the images table to HTML because the markdown one was changing the size of the images making the top alignment wrong.

### Before

| Default sidebar | Hide some items | Add new items | Reorder items |
| --------------- | --------------- | ------------- | ------------- |
| ![default sidebar](https://raw.githubusercontent.com/elchininet/custom-sidebar/master/images/default-sidebar.png) | ![default sidebar](https://raw.githubusercontent.com/elchininet/custom-sidebar/master/images/hide-items.png) | ![default sidebar](https://raw.githubusercontent.com/elchininet/custom-sidebar/master/images/new-items.png) | ![default sidebar](https://raw.githubusercontent.com/elchininet/custom-sidebar/master/images/reorder-items.png) |

### After

<table>
  <thead>
    <tr>
      <th width="25%">Default sidebar</th>
      <th width="25%">Hide some items</th>
      <th width="25%">Add new items</th>
      <th width="25%">Reorder items</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>
        <img src="https://raw.githubusercontent.com/elchininet/custom-sidebar/master/images/default-sidebar.png" alt="default sidebar" />
      </td>
      <td>
        <img src="https://raw.githubusercontent.com/elchininet/custom-sidebar/master/images/hide-items.png" alt="hide items" />
      </td>
      <td>
        <img src="https://raw.githubusercontent.com/elchininet/custom-sidebar/master/images/new-items.png" alt="new items" />
      </td>
      <td>
        <img src="https://raw.githubusercontent.com/elchininet/custom-sidebar/master/images/reorder-items.png" alt="reorder items" />
      </td>
    </tr>
  </tbody>
</table>