### PR TITLE
Make it sure to run the plugin just once

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,13 @@ You can install the plugin manually or through [HACS], not both. If you install 
 ```yaml
 frontend:
   extra_module_url:
-    - /hacsfiles/custom-sidebar/custom-sidebar.js
+    - /hacsfiles/custom-sidebar/custom-sidebar.js?v1.0.0
 ```
 
-10. Restart Home Assistant
+10. Make sure you add the correct version at the end of the URL (e.g. `?v=1.0.0`) because in this way you make Home Assistant to load the new version instead of a version stored in cache
+12. Restart Home Assistant
+
+>Note
 
 ### Manual installation
 
@@ -67,10 +70,11 @@ frontend:
 ```yaml
 frontend:
   extra_module_url:
-    - /local/custom-sidebar.js
+    - /local/custom-sidebar.js?v1.0.0
 ```
 
-4. Restart Home Assistant
+4. Make sure you add the correct version at the end of the URL (e.g. `?v=1.0.0`) because in this way you make Home Assistant to load the new version instead of a version stored in cache
+5. Restart Home Assistant
 
 ## Configuration
 

--- a/src/custom-sidebar.ts
+++ b/src/custom-sidebar.ts
@@ -23,10 +23,6 @@ import {
     getFinalOrder
 } from '@utilities';
 
-logVersionToConsole();
-
-const configPromise = fetchConfig();
-
 class CustomSidebar {
 
     constructor() {
@@ -47,9 +43,11 @@ class CustomSidebar {
 
         selector.listen();
 
+        this._configPromise = fetchConfig();
         this._process();
     }
 
+    private _configPromise: Promise<Config>;
     private _homeAssistant: HAElement;
     private _partialPanelResolver: HAElement;
     private _sidebar: HAElement;
@@ -57,7 +55,7 @@ class CustomSidebar {
     private async _getOrder(): Promise<ConfigOrder[]> {
         const user = await this._getCurrentUser();
         const device = this._getCurrentDevice();
-        return configPromise
+        return this._configPromise
             .then((config: Config) => {
                 return getFinalOrder(
                     user,
@@ -70,7 +68,7 @@ class CustomSidebar {
 
     private _getElementWithConfig<P>(promise: Promise<P>): Promise<[Config, Awaited<P>]> {
         return Promise.all([
-            configPromise,
+            this._configPromise,
             promise
         ]);
     }
@@ -302,4 +300,7 @@ class CustomSidebar {
 
 }
 
-new CustomSidebar();
+if (!window.CustomSidebar) {
+    logVersionToConsole();
+    window.CustomSidebar = new CustomSidebar();
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -71,3 +71,9 @@ export interface Config {
     order: ConfigOrder[];
     exceptions?: ConfigException[];
 }
+
+declare global {
+    interface Window {
+        CustomSidebar: {};
+    }
+}


### PR DESCRIPTION
When the plugin is installed via HACS and added as an `extra_module_url` it loads two times in lovelace dashboards. This pull request ensures that the plugin runs only once avoiding processing the sidebar two times.

>Note: as part of this pull request, a note has been added to the installation instructions to add a hash at the end of the URL to avoid caching issues.