### PR TITLE
Fix the exact property behaviour to give more flexibility to the matches

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,12 +111,12 @@ Add a file named `sidebar-order.json` or `sidebar-order.yaml` into your `<config
 
 | Property  | Type    | Required | Description |
 | --------- | ------- | -------- | ----------- |
-| item      | String  | true     | This is a string that will be used to match each sidebar item by its text or its `data-panel` property. In the case of the item text, it can be a substring such as `developer` instead of `Developer Tools` and it is case insensitive. |
+| item      | String  | true     | This is a string that will be used to match each sidebar item by its text or its `data-panel` property. In the case of the item text, it can be a substring such as `developer` instead of `Developer Tools`. If the `exact` property is not set, it is case insensitive. |
 | name      | String  | false     | Changes the name of the sidebar item |
 | order     | Number  | false     | Sets the order number of the sidebar item |
 | bottom    | Boolean | false     | Setting this property to `true` will group the item with the bottom items (Configuration, Developer Tools, etc) |
 | hide      | Boolean | false     | Setting this property to `true` will hide the sidebar item |
-| exact     | Boolean | false     | Specifies whether the `item` string match should be an exact match of the item text instead of a substring |
+| exact     | Boolean | false     | Specifies whether the `item` string match should be an exact match of the item text or an exact match of the `data-panel` attribute (case sensitive) |
 | href      | String  | false     | Specifies the `href` of the sidebar item |
 | target    | String  | false     | Specifies the [target property] of the sidebar item |
 | icon      | String  | false     | Specifies the icon of the sidebar item |

--- a/src/custom-sidebar.ts
+++ b/src/custom-sidebar.ts
@@ -180,13 +180,17 @@ class CustomSidebar {
                         ? undefined
                         : Array.from(items).find((element: Element): boolean => {
                             const text = element.querySelector(SELECTOR.ITEM_TEXT).textContent.trim();
+                            const dataPanel = element.getAttribute(ATTRIBUTE.PANEL);
                             if (exact) {
-                                return text === item;
+                                return (
+                                    text === item ||
+                                    dataPanel === item
+                                );
                             }
-                            return (
-                                text.toLocaleLowerCase().includes(itemLowerCase) ||
-                                element.getAttribute(ATTRIBUTE.PANEL).toLocaleLowerCase() === itemLowerCase
-                            );
+                            if (dataPanel.toLocaleLowerCase() === itemLowerCase) {
+                                return true;
+                            }
+                            return text.toLocaleLowerCase().includes(itemLowerCase);
                         });
                     if (element) {
                         element.setAttribute(ATTRIBUTE.PROCESSED, 'true');


### PR DESCRIPTION
This pull request changes the `exact` property behaviour to make it more flexible to match elements.

For example:

1. `<a data-panel="ui-configured">UI Configured</a>`
2. `<a data-panel="config">Instellingen</a>`
3. `<a data-panel="instellingen">Instellingen</a>`

### Before

* With item in `config` and `exact` in `false` it matched number 1.
* With item in `config` and `exact` in `true` it didn‘t match any item because none of them have `config` as text.

### After

* With item in `config` and `exact` in `false` it matches number 1.
* With item in `config` and `exact` in `true` it matches number 2 because its `data-panel` is exactly `config`.