### PR TITLE
[NEW FEATURE] Implement JavaScript templating system

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,19 +109,22 @@ Add a file named `sidebar-config.json` or `sidebar-config.yaml` into your `<conf
 
 #### Item properties
 
-| Property  | Type    | Required  | Description |
-| --------- | ------- | --------- | ----------- |
-| item      | String  | true      | This is a string that will be used to match each sidebar item by its text, its `data-panel` attribute or its `href`. If the `exact` property is not set, it is case insensitive and it can be a substring such as `developer` instead of `Developer Tools` or `KITCHEN` instead of `kitchen-lights`. |
-| match     | String  | false     | This property will define which string will be used to match the `item` property. It has three possible values "text" (default) to match the text content of the element, "data-panel" to match the `data-panel` attribute of the element, or "href", to match the `href` attribute of the element |
-| exact     | Boolean | false     | Specifies whether the `item` string match should be an exact match (`true`) or not (`false`). |
-| name      | String  | false     | Changes the name of the sidebar item |
-| order     | Number  | false     | Sets the order number of the sidebar item |
-| bottom    | Boolean | false     | Setting this property to `true` will group the item with the bottom items (Configuration, Developer Tools, etc) |
-| hide      | Boolean | false     | Setting this property to `true` will hide the sidebar item |
-| href      | String  | false     | Specifies the `href` of the sidebar item |
-| target    | String  | false     | Specifies the [target property] of the sidebar item |
-| icon      | String  | false     | Specifies the icon of the sidebar item |
-| new_item  | Boolean | false     | Set this property to `true` to create a new item in the sidebar. **Using this option makes `href` and `icon` required properties** |
+| Property                  | Type    | Required  | Description |
+| ------------------------- | ------- | --------- | ----------- |
+| item                      | String  | true      | This is a string that will be used to match each sidebar item by its text, its `data-panel` attribute or its `href`. If the `exact` property is not set, it is case insensitive and it can be a substring such as `developer` instead of `Developer Tools` or `KITCHEN` instead of `kitchen-lights`. |
+| match                     | String  | false     | This property will define which string will be used to match the `item` property. It has three possible values "text" (default) to match the text content of the element, "data-panel" to match the `data-panel` attribute of the element, or "href", to match the `href` attribute of the element |
+| exact                     | Boolean | false     | Specifies whether the `item` string match should be an exact match (`true`) or not (`false`). |
+| name<sup>\*</sup>         | String  | false     | Changes the name of the sidebar item |
+| notification<sup>\*</sup> | String  | false     | Add a notification badge to the sidebar item |
+| order                     | Number  | false     | Sets the order number of the sidebar item |
+| bottom                    | Boolean | false     | Setting this property to `true` will group the item with the bottom items (Configuration, Developer Tools, etc)         |
+| hide                      | Boolean | false     | Setting this property to `true` will hide the sidebar item |
+| href                      | String  | false     | Specifies the `href` of the sidebar item |
+| target                    | String  | false     | Specifies the [target property] of the sidebar item |
+| icon                      | String  | false     | Specifies the icon of the sidebar item |
+| new_item                  | Boolean | false     | Set this property to `true` to create a new item in the sidebar. **Using this option makes `href` and `icon` required properties** |
+
+>\* These properties allow [JavaScript templates](#javascript-templates).
 
 Short example in `JSON` format:
 
@@ -229,6 +232,55 @@ exceptions:
 * You cannot use `device` and `not_device` at the same time, doing so will end in an error
 * Pay attention to `base_order` property. If it's set to `false` (default value), the main `config.order` will be ignored, leaving you with default sidebar modified only by the exception's orders
 
+## JavaScript templates
+
+Some properties, as `name` and `notification`, admit `JavaScript` templates. This templating system is not [the same that Home Assistant implements](https://www.home-assistant.io/docs/configuration/templating). It is basically a `JavaScript` code block in which you can use certain client-side objects, variables and methods. To set a property as a `JavaScript` template block, include the code between three square brackets `[[[ JavaScript code ]]]`. If you don‘t use the square brackets, the property will be interpreted as a regular string.
+
+The `JavaScript` code will be taken as something that you want to return, but if you have a more complex logic, you can create your own variables and return the desired result at the end.
+
+The entities and domains used in the templates will be stored so if the state of these entities change, it will update the templates used in the configuration.
+
+### JavaScript templates example
+
+The next example will add the number of `HACS` updates as a notification in the `HACS` item in the sidebar. In case that there are no updates, an empty string is returned and in these cases the notification will not be displayed.
+
+It also creates a new item that redirects to the `Home Assistant` info page with a dynamic text with the word "Info" followed by the installed Supervisor version  between parentheses.
+
+#### in `JSON` format:
+
+```json5
+{
+  "order": [
+    {
+      "item": "hacs",
+      "notification": "[[[ state_attr('sensor.hacs', 'repositories').length || '' ]]]"
+    },
+    {
+      "new_item": true,
+      "item": "info",
+      "name": "[[[ 'Info (' + state_attr('update.home_assistant_supervisor_update', 'latest_version') + ')' ]]]",
+      "href": "/config/info",
+      "icon": "mdi:information-outline"
+    }
+  ]
+}
+```
+
+#### in `YAML` format:
+
+```yaml
+order:
+  - item: hacs
+    notification: '[[[ state_attr("sensor.hacs", "repositories").length || '' ]]]'
+  - new_item: true
+    item: info
+    name: '[[[ "Info (" + state_attr("update.home_assistant_supervisor_update", "latest_version") + ")" ]]]'
+    href: '/config/info'
+    icon: mdi:information-outline
+```
+
+>Note: `Custom Sidebar` uses [Home Assistant Javascript Templates] for the templating system. To know all the objects, variables and methods available in the `JavaScript` templates, consult the [proper section](https://github.com/elchininet/home-assistant-javascript-templates?tab=readme-ov-file#objects-and-methods-available-in-the-templates) in the repository.
+
 ## Home Assistant built-in sidebar configuration options
 
 Check out Home Assistant's native sidebar tools, maybe it will be enough for your needs.
@@ -297,4 +349,5 @@ order:
 [example sidebar-config.yaml]: https://raw.githubusercontent.com/elchininet/custom-sidebar/master/sidebar-config.yaml
 [target property]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#target
 [user-agent]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent
+[Home Assistant Javascript Templates]: https://github.com/elchininet/home-assistant-javascript-templates
 [Home Assistant's Iframe Panel feature]: https://www.home-assistant.io/integrations/panel_iframe/

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
+    "home-assistant-javascript-templates": "^2.0.0",
     "home-assistant-query-selector": "^4.2.0",
     "js-yaml": "^4.1.0"
   }

--- a/sidebar-config.json
+++ b/sidebar-config.json
@@ -39,7 +39,8 @@
     },
     {
       "item": "hacs",
-      "order": 6
+      "order": 6,
+      "notification": "[[[ state_attr('sensor.hacs', 'repositories').length || '' ]]]"
     },
     {
       "item": "config",

--- a/sidebar-config.yaml
+++ b/sidebar-config.yaml
@@ -26,6 +26,7 @@ order:
     order: 5
   - item: hacs
     order: 6
+    notification: '[[[ state_attr("sensor.hacs", "repositories").length || '' ]]]'
   - item: config
     bottom: true
     order: 7

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -9,6 +9,7 @@ export const UNDEFINED_TYPE = 'undefined';
 export enum ELEMENT {
     SIDEBAR = 'ha-sidebar',
     PAPER_LISTBOX = 'paper-listbox',
+    PAPER_ICON_ITEM = 'paper-icon-item',
     HA_SVG_ICON = 'ha-svg-icon',
     HA_ICON = 'ha-icon'
 }
@@ -18,13 +19,15 @@ export enum SELECTOR {
     TITLE = '.title',
     ITEM = 'a[role="option"]',
     SPACER = '.spacer',
-    ITEM_TEXT = '.item-text'
+    ITEM_TEXT = '.item-text',
+    NOTIFICATION_BADGE = '.notification-badge'
 }
 
 export enum ATTRIBUTE {
     PANEL = 'data-panel',
     ROLE = 'role',
     PROCESSED = 'data-processed',
+    WITH_NOTIFICATION = 'data-notification',
     ARIA_SELECTED = 'aria-selected',
     ARIA_DISABLED = 'aria-disabled',
     HREF = 'href',
@@ -34,3 +37,8 @@ export enum ATTRIBUTE {
 export enum EVENT {
     MOUSEDOWN = 'mousedown'
 }
+
+export const TEMPLATE_REG = /^\s*\[\[\[([\s\S]+)\]\]\]\s*$/;
+export const ENTITIES_REGEXP = /(?:^|\W)(?:states|is_state|state_attr|is_state_attr|has_value)\s*\(\s*['"]\s*([a-z0-9_.]+)\s*['"]|(?:^|\W)states\s*\[\s*["']\s*([a-z0-9_.]+)\s*["']/g;
+export const CSS_CLEANER_REGEXP = /(\s*)([\w-]+\s*:\s*[^;]+;?|\})(\s*)/g;
+export const DOMAIN_REGEXP = /^([a-z]+)[\w.]*$/;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,15 +1,13 @@
-export interface User {
-    name: string;
-    is_admin: boolean;
+import { HomeAssistant, Hass } from 'home-assistant-javascript-templates';
+
+export interface HassObject extends Hass {
+    config: {
+        version: string;
+    };
 }
 
-export interface HomeAssistant extends HTMLElement {
-	hass: {
-        user: User;
-        config: {
-            version: string;
-        };
-    };
+export interface HomeAsssistantExtended extends HomeAssistant {
+    hass: HassObject;
 }
 
 export interface PartialPanelResolver extends HTMLElement {
@@ -34,6 +32,7 @@ export interface ConfigItem {
     match?: `${Match}`;
     exact?: boolean;
     name?: string;
+    notification?: string;
     order?: number;
     bottom?: boolean;
     hide?: boolean;
@@ -51,7 +50,7 @@ export interface ConfigNewItem extends Omit<ConfigItem, 'new_item'> {
 }
 
 export type ConfigOrder = ConfigItem | ConfigNewItem;
-export type ConfigOrderWithItem = ConfigOrder & { element?: Element };
+export type ConfigOrderWithItem = ConfigOrder & { element?: HTMLAnchorElement };
 
 interface ConfigExceptionBase {
     order: ConfigOrder[];
@@ -90,8 +89,34 @@ export interface Config {
     exceptions?: ConfigException[];
 }
 
+export type SuscriberEvent = {
+    event_type: string;
+    data: {
+        entity_id: string;
+        old_state?: {
+            state: string;
+        };
+        new_state: {
+            state: string;
+        };
+    }
+};
+
+export type SuscriberCallback = (event: SuscriberEvent) => void;
+export type SuscriberOptions = {
+    type: string;
+    event_type: string;
+};
+
+export interface HassConnection {
+    conn: {
+        subscribeMessage: (callback: SuscriberCallback, options: SuscriberOptions) => void;
+    }
+}
+
 declare global {
     interface Window {
         CustomSidebar: {};
+        hassConnection: Promise<HassConnection>;
     }
 }

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -3,7 +3,8 @@ import {
     NAMESPACE,
     MAX_ATTEMPTS,
     RETRY_DELAY,
-    UNDEFINED_TYPE
+    UNDEFINED_TYPE,
+    CSS_CLEANER_REGEXP
 } from '@constants';
 import { version } from '../../package.json';
 
@@ -125,4 +126,19 @@ export const getFinalOrder = (
         return flatConfigOrder(exceptionsOrder);
     }
     return flatConfigOrder(order);
+};
+
+const getElementName = (elem: Element | ShadowRoot): string => {
+	if (elem instanceof ShadowRoot) {
+		return elem.host.localName;
+	}
+	return elem.localName;
+};
+
+export const addStyle = (css: string, elem: Element | ShadowRoot): void => {
+	const name = getElementName(elem);
+    const style = document.createElement('style');
+    style.setAttribute('id', `${NAMESPACE}_${name}`);
+    elem.appendChild(style);
+	style.innerHTML = css.replace(CSS_CLEANER_REGEXP, '$2');
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -384,6 +384,11 @@ helpertypes@^0.0.19:
   resolved "https://registry.yarnpkg.com/helpertypes/-/helpertypes-0.0.19.tgz#6f8cb18e4e1fad73dc103b98e624ac85cb06a720"
   integrity sha512-J00e55zffgi3yVnUp0UdbMztNkr2PnizEkOe9URNohnrNhW5X0QpegkuLpOmFQInpi93Nb8MCjQRHAiCDF42NQ==
 
+home-assistant-javascript-templates@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/home-assistant-javascript-templates/-/home-assistant-javascript-templates-2.0.0.tgz#dba33769ce21cf049e99743ddf2cea8ba9d6926b"
+  integrity sha512-9uK8uf/uxVtjkhHoE3vAfT13wgtw2yUwn7vkg1lepKpVpfrj9eGpoK50+LJrZW4NMq6fujC/MzpDD8b2Ve0lFg==
+
 home-assistant-query-selector@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/home-assistant-query-selector/-/home-assistant-query-selector-4.2.0.tgz#009ef948f5b9079291a1bc0284c21efa39e82926"


### PR DESCRIPTION
This pull request should not be a breaking change but it will bump the version of the library to a major version because it changes many things in the code, so users should be cautelous installing the update and report any unwanted issue.

This pull request implements `JavaScript` templating in the library. At the moment, the `JavaScript` templates can be added to the `name` property and to a new property named `notification` that will add a notification badge in the item.

| Property                  | Type    | Required  | Description |
| ------------------------- | ------- | --------- | ----------- |
| name<sup>\*</sup>         | String  | false     | Changes the name of the sidebar item |
| notification<sup>\*</sup> | String  | false     | Add a notification badge to the sidebar item |

>\* These properties allow [JavaScript templates](#javascript-templates).

## JavaScript templates

Some properties, as `name` and `notification`, admit `JavaScript` templates. This templating system is not [the same that Home Assistant implements](https://www.home-assistant.io/docs/configuration/templating). It is basically a `JavaScript` code block in which you can use certain client-side objects, variables and methods. To set a property as a `JavaScript` template block, include the code between three square brackets `[[[ JavaScript code ]]]`. If you don‘t use the square brackets, the property will be interpreted as a regular string.

The `JavaScript` code will be taken as something that you want to return, but if you have a more complex logic, you can create your own variables and return the desired result at the end.

The entities and domains used in the templates will be stored so if the state of these entities change, it will update the templates used in the configuration.

### JavaScript templates example

The next example will add the number of `HACS` updates as a notification in the `HACS` item in the sidebar. In case that there are no updates, an empty string is returned and in these cases the notification will not be displayed.

It also creates a new item that redirects to the `Home Assistant` info page with a dynamic text with the word "Info" followed by the installed Supervisor version  between parentheses.

#### in `JSON` format:

```json5
{
  "order": [
    {
      "item": "hacs",
      "notification": "[[[ state_attr('sensor.hacs', 'repositories').length || '' ]]]"
    },
    {
      "new_item": true,
      "item": "info",
      "name": "[[[ 'Info (' + state_attr('update.home_assistant_supervisor_update', 'latest_version') + ')' ]]]",
      "href": "/config/info",
      "icon": "mdi:information-outline"
    }
  ]
}
```

#### in `YAML` format:

```yaml
order:
  - item: hacs
    notification: '[[[ state_attr("sensor.hacs", "repositories").length || '' ]]]'
  - new_item: true
    item: info
    name: '[[[ "Info (" + state_attr("update.home_assistant_supervisor_update", "latest_version") + ")" ]]]'
    href: '/config/info'
    icon: mdi:information-outline
```

>Note: `Custom Sidebar` uses [Home Assistant Javascript Templates] for the templating system. To know all the objects, variables and methods available in the `JavaScript` templates, consult the [proper section](https://github.com/elchininet/home-assistant-javascript-templates?tab=readme-ov-file#objects-and-methods-available-in-the-templates) in the repository.

[Home Assistant Javascript Templates]: https://github.com/elchininet/home-assistant-javascript-templates