### PR TITLE
Update home-assistant-javascript-templates library to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "home-assistant-javascript-templates": "^2.0.0",
+    "home-assistant-javascript-templates": "^3.0.0",
     "home-assistant-query-selector": "^4.2.0",
     "js-yaml": "^4.1.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -384,10 +384,10 @@ helpertypes@^0.0.19:
   resolved "https://registry.yarnpkg.com/helpertypes/-/helpertypes-0.0.19.tgz#6f8cb18e4e1fad73dc103b98e624ac85cb06a720"
   integrity sha512-J00e55zffgi3yVnUp0UdbMztNkr2PnizEkOe9URNohnrNhW5X0QpegkuLpOmFQInpi93Nb8MCjQRHAiCDF42NQ==
 
-home-assistant-javascript-templates@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/home-assistant-javascript-templates/-/home-assistant-javascript-templates-2.0.0.tgz#dba33769ce21cf049e99743ddf2cea8ba9d6926b"
-  integrity sha512-9uK8uf/uxVtjkhHoE3vAfT13wgtw2yUwn7vkg1lepKpVpfrj9eGpoK50+LJrZW4NMq6fujC/MzpDD8b2Ve0lFg==
+home-assistant-javascript-templates@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/home-assistant-javascript-templates/-/home-assistant-javascript-templates-3.0.0.tgz#37533b7293c2d1d9bd5d539d490dbcecbcc5929d"
+  integrity sha512-ed8FeF8iTAXK3aLjAPu5a5atLpqEI9ARQ9v32PYC38I4H9zaA+VdioWDPftaQYJL2KQI6Rb9ahJl73AKu+9EYg==
 
 home-assistant-query-selector@^4.2.0:
   version "4.2.0"


### PR DESCRIPTION
This pull request updates the `home-assistant-javascript-templates` package to its latest version.