### PR TITLE
[BREAKING CHANGE] Create bundle json

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -86,7 +86,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            dist/custom-sidebar.js
+            dist/custom-sidebar-json.js
             dist/custom-sidebar-yaml.js
           body: |
             ${{ steps.build_changelog.outputs.changelog }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -86,6 +86,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: |
+            dist/custom-sidebar.js
             dist/custom-sidebar-json.js
             dist/custom-sidebar-yaml.js
           body: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /node_modules
+.DS_Store
 /dist
 /.yalc
 /yalc.lock

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Custom [HACS] plugin that allows you to rearrange, hide, and add menu items to [
   </tbody>
 </table>
 
-This is a refactor of [custom-sidebar-v2] by @galloween, which unfortunatelly is now unmaintained and archived. In its beginning, @galloween's code was a refactor of the [original Custom Sidebar] plugin by @Villhellm (R.I.P.). This version refactored completely @galloween's code allowing to use a configuration in `JSON` (as @galloween's version) or in `YAML` (as @Villhellm's one), and using [home-assistant-query-selector] to make it less likely to break with future Home Assistant front-end updates.
+This is a refactor of [custom-sidebar-v2] by @galloween, which unfortunatelly is now unmaintained and archived. In its beginning, @galloween's code was a refactor of the [original Custom Sidebar] plugin by @Villhellm (R.I.P.). This version refactored completely @galloween's code allowing to use a configuration in `JSON` (as @galloween's version) or in `YAML` (as @Villhellm's one), fixing several bugs, improving performance, and using [home-assistant-query-selector] to make it less likely to break with future Home Assistant front-end updates.
 
 ## Installation
 
@@ -56,7 +56,7 @@ You can install the plugin manually or through [HACS], not both. If you install 
 ```yaml
 frontend:
   extra_module_url:
-    - /hacsfiles/custom-sidebar/custom-sidebar.js?v1.0.0
+    - /hacsfiles/custom-sidebar/custom-sidebar-json.js?v1.0.0
 ```
 
 #### If you want to use a `YAML` configuration
@@ -73,7 +73,7 @@ frontend:
 ### Manual installation
 
 1. Download the latest [custom-sidebar release]
-2. Copy `custom-sidebar.js` or `custom-sidebar-yaml.js` into `<config directory>/www/` (depending on the configuration format that you are going to use, `JSON` or `YAML`)
+2. Copy `custom-sidebar-json.js` or `custom-sidebar-yaml.js` into `<config directory>/www/` (depending on the configuration format that you are going to use, `JSON` or `YAML`)
 3. Add the url of the plugin as an [extra_module_url] in your `confgiguration.yaml` (unless you use [browser_mod]):
 
 #### If you want to use a `JSON` configuration
@@ -81,7 +81,7 @@ frontend:
 ```yaml
 frontend:
   extra_module_url:
-    - /local/custom-sidebar.js?v1.0.0
+    - /local/custom-sidebar-json.js?v1.0.0
 ```
 
 #### If you want to use a `YAML` configuration
@@ -97,7 +97,7 @@ frontend:
 
 ## Configuration
 
-Depending on the file that you have added to [extra_module_url], you will need to add your configuration in `JSON` or `YAML` format. If you used `custom-sidebar.js` you need to provide the configuration in `JSON` format. If you have used `custom-sidebar-yaml.js` you need to provide the configuration in `YAML` format.
+Depending on the file that you have added to [extra_module_url], you will need to add your configuration in `JSON` or `YAML` format. If you used `custom-sidebar-json.js` you need to provide the configuration in `JSON` format. If you have used `custom-sidebar-yaml.js` you need to provide the configuration in `YAML` format.
 
 Add a file named `sidebar-config.json` or `sidebar-config.yaml` into your `<config directory>/www/` directory. It could be easier if you copy the [example sidebar-config.json] or the [example sidebar-config.yaml] file, delete the `id` parameter, and edit it to match your needs.
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,23 +8,49 @@ import istanbul from 'rollup-plugin-istanbul';
 
 const CONFIG_REPLACER = '%CONFIG%';
 
-const plugins = [
+const bundlePlugins = [
     nodeResolve(),
     json(),
+    ts({
+        browserslist: false
+    }),
+    terser({
+        output: {
+            comments: false
+        }
+    })
+];
+
+const testBundlePlugins = [
+    nodeResolve(),
+    json(),
+    ts({
+        browserslist: false,
+        tsconfig: resolvedConfig => ({
+            ...resolvedConfig,
+            removeComments: false
+        })                
+    }),
+    istanbul({
+        exclude: [
+            'node_modules/**/*',
+            'package.json'
+        ]
+    })
 ];
 
 export default [
     {
+        plugins: bundlePlugins,
+        input: 'src/checker.ts',
+        output: {
+            file: 'dist/custom-sidebar.js',
+            format: 'iife'
+        }
+    },
+    {
         plugins: [
-            ...plugins,
-            ts({
-                browserslist: false
-            }),
-            terser({
-                output: {
-                    comments: false
-                }
-            }),
+            ...bundlePlugins,
             replace({
                 [CONFIG_REPLACER]: 'JSON',
                 preventAssignment: true,
@@ -33,21 +59,13 @@ export default [
         ],
         input: 'src/custom-sidebar.ts',
         output: {
-            file: 'dist/custom-sidebar.js',
+            file: 'dist/custom-sidebar-json.js',
             format: 'iife'
         }
     },
     {
         plugins: [
-            ...plugins,
-            ts({
-                browserslist: false
-            }),
-            terser({
-                output: {
-                    comments: false
-                }
-            }),
+            ...bundlePlugins,
             replace({
                 [CONFIG_REPLACER]: 'YAML',
                 preventAssignment: true,
@@ -70,25 +88,12 @@ export default [
     },
     {
         plugins: [
-            ...plugins,
-            ts({
-                browserslist: false,
-                tsconfig: resolvedConfig => ({
-                    ...resolvedConfig,
-                    removeComments: false
-                })                
-            }),
+            ...testBundlePlugins,
             replace({
                 [CONFIG_REPLACER]: 'JSON',
                 preventAssignment: true,
                 delimiters: ['', '']
-            }),
-            istanbul({
-				exclude: [
-					'node_modules/**/*',
-					'package.json'
-				]
-			})
+            })
         ],
         input: 'src/custom-sidebar.ts',
         output: {

--- a/src/checker.ts
+++ b/src/checker.ts
@@ -1,0 +1,11 @@
+import { NAMESPACE } from '@constants';
+import { getPromisableElement } from '@utilities';
+
+getPromisableElement(
+    () => window.CustomSidebar,
+    (customSideBar: {}) => !!customSideBar
+).then((sidebar) => {
+    if (!sidebar) {
+        throw Error(`${NAMESPACE}: you need to add the plugin as a frontend > extra_module_url module.\nCheck the documentation: https://github.com/elchininet/custom-sidebar#installation`);
+    }
+});

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,6 +1,6 @@
 export const NAMESPACE = 'custom-sidebar';
 export const CONFIG_PATH = '/local/sidebar-config';
-export const MAX_ATTEMPTS = 500;
+export const MAX_ATTEMPTS = 100;
 export const RETRY_DELAY = 50;
 
 export const STRING_TYPE = 'string';

--- a/tests/05 - interactions.spec.ts
+++ b/tests/05 - interactions.spec.ts
@@ -89,7 +89,7 @@ test('Do not move the clicked item outside the viewport', async ({ page }) => {
   await expect(page.locator(SELECTORS.HUI_VIEW)).toBeVisible();
   await expect(page.locator(SELECTORS.HA_SIDEBAR)).toHaveScreenshot('02-sidebar-small-viewport.png');
 
-  await page.locator(SELECTORS.SIDEBAR_ITEMS.INTEGRATIONS).click();
+  await page.locator(SELECTORS.SIDEBAR_ITEMS.INTEGRATIONS).click({ delay: 50 });
 
   await expect(page.locator(SELECTORS.SIDEBAR_ITEMS.INTEGRATIONS)).toBeInViewport();
 


### PR DESCRIPTION
HACS automatically installs the `JavaScript` bundle with the name of the library as a lovelace resource, but this plugin needs to be installed as a fontend [extra_module_url](https://www.home-assistant.io/integrations/frontend/#extra_module_url) because it needs to work in all dashboards and not only in the lovelace ones.

This provoked that the plugin was loaded twice in lovelace dashboards (one, the HACS import and the second the fontend `extra_module_url`). In case of `YAML` installations, the `JSON` installation is loaded in lovelace dasboards through HACS together with the `YAML` version loaded through the frontend `extra_module_url` (something that could provoke issues).

This pull request solves this. The `custom-sidebar.js` bundle is a small file of 1KB with a simple logic to check if the plugin was loaded. This file will be installed automatically by HACS and will be loaded in lovelace dashboards. If it detects that `custom-sidebar` has not been loaded, it throws an error:

```bash
custom-sidebar: you need to add the plugin as a frontend > extra_module_url module.
Check the documentation: https://github.com/elchininet/custom-sidebar#installation
```

To install the `JSON` version, one needs to add the file `custom-sidebar-json.js` as a frontend `extra_module_url`. (the `YAML` version keeps as before and one needs to install the file `custom-sidebar-yaml.js`).