### PR TITLE
Other way of checking errors

### DIFF
--- a/tests/07 - fetch-config-errors.spec.ts
+++ b/tests/07 - fetch-config-errors.spec.ts
@@ -5,6 +5,8 @@ const ERROR_PREFIX = 'custom-sidebar:';
 
 test('JSON not found', async ({ page }) => {
 
+    const errors: string[] = [];
+
     await page.route('local/sidebar-config.json*', async route => {
         await route.fulfill({
             status: 404,
@@ -14,15 +16,22 @@ test('JSON not found', async ({ page }) => {
     });
 
     page.on('pageerror', error => {
-        expect(error.message).toBe(`${ERROR_PREFIX} JSON config file not found.\nMake sure you have valid config in /config/www/sidebar-order.json file.`);
+        errors.push(error.message);
     });
 
     await page.goto('/');
     await expect(page.locator(SELECTORS.HA_SIDEBAR)).toBeVisible();
+    expect(errors).toEqual(
+        expect.arrayContaining([
+            `${ERROR_PREFIX} JSON config file not found.\nMake sure you have valid config in /config/www/sidebar-order.json file.`
+        ])
+    );
 
 });
 
 test('JSON server error', async ({ page }) => {
+
+    const errors: string[] = [];
 
     await page.route('local/sidebar-config.json*', async route => {
         await route.fulfill({
@@ -33,30 +42,44 @@ test('JSON server error', async ({ page }) => {
     });
 
     page.on('pageerror', error => {
-        expect(error.message).toBe(`${ERROR_PREFIX} JSON config file not found.\nMake sure you have valid config in /config/www/sidebar-order.json file.`);
+        errors.push(error.message);
     });
 
     await page.goto('/');
     await expect(page.locator(SELECTORS.HA_SIDEBAR)).toBeVisible();
+    expect(errors).toEqual(
+        expect.arrayContaining([
+            `${ERROR_PREFIX} JSON config file not found.\nMake sure you have valid config in /config/www/sidebar-order.json file.`
+        ])
+    );
 
 });
 
 test('JSON malformed', async ({ page }) => {
+
+    const errors: string[] = [];
 
     await page.route('local/sidebar-config.json*', async route => {
         await route.fulfill({ body: 'html' });
     });
 
     page.on('pageerror', error => {
-        expect(error.message).toBe(`${ERROR_PREFIX} Unexpected token \'h\', "html" is not valid JSON`);
+        errors.push(error.message);
     });
 
     await page.goto('/');
     await expect(page.locator(SELECTORS.HA_SIDEBAR)).toBeVisible();
+    expect(errors).toEqual(
+        expect.arrayContaining([
+            `${ERROR_PREFIX} Unexpected token \'h\', "html" is not valid JSON`
+        ])
+    );
 
 });
 
 test('JSON id warning', async ({ page }) => {
+
+    const warnings: string[] = [];
 
     await page.route('local/sidebar-config.json*', async route => {
         const json = { title: 'Custom Title', order: [], id: 'example_json'};
@@ -65,11 +88,16 @@ test('JSON id warning', async ({ page }) => {
 
     page.on('console', message => {
         if (message.type() === 'warning') {
-            expect(message.text()).toBe(`${ERROR_PREFIX} You seem to be using the example configuration.\nMake sure you have valid config in /config/www/sidebar-order.json file.`);
+            warnings.push(message.text());
         }
     });
 
     await page.goto('/');
     await expect(page.locator(SELECTORS.HA_SIDEBAR)).toBeVisible();
+    expect(warnings).toEqual(
+        expect.arrayContaining([
+            `${ERROR_PREFIX} You seem to be using the example configuration.\nMake sure you have valid config in /config/www/sidebar-order.json file.`
+        ])
+    );
 
 });

--- a/tests/08 - validator-errors.spec.ts
+++ b/tests/08 - validator-errors.spec.ts
@@ -6,35 +6,51 @@ const ERROR_PREFIX = 'custom-sidebar: Invalid configuration';
 
 test('Validation: no order parameter', async ({ page }) => {
 
+    const errors: string[] = [];
+
     await fulfillJson(page, {
         title: 'Custom Title'
     });
 
     page.on('pageerror', error => {
-        expect(error.message).toBe(`${ERROR_PREFIX}, "order" parameter is required`);
+        errors.push(error.message);
     });
 
     await page.goto('/');
     await expect(page.locator(SELECTORS.HA_SIDEBAR)).toBeVisible();
+    expect(errors).toEqual(
+        expect.arrayContaining([
+            `${ERROR_PREFIX}, "order" parameter is required`
+        ])
+    );
 
 });
 
 test('Validation: order parameter should be an array', async ({ page }) => {
+
+    const errors: string[] = [];
 
     await fulfillJson(page, {
         order: {}
     });
 
     page.on('pageerror', error => {
-        expect(error.message).toBe(`${ERROR_PREFIX}, "order" parameter should be an array`);
+        errors.push(error.message);
     });
 
     await page.goto('/');
     await expect(page.locator(SELECTORS.HA_SIDEBAR)).toBeVisible();
+    expect(errors).toEqual(
+        expect.arrayContaining([
+            `${ERROR_PREFIX}, "order" parameter should be an array`
+        ])
+    );
 
 });
 
 test('Validation: every item in order should have an "item" property', async ({ page }) => {
+
+    const errors: string[] = [];
 
     await fulfillJson(page, {
         order: [
@@ -48,15 +64,22 @@ test('Validation: every item in order should have an "item" property', async ({ 
     });
 
     page.on('pageerror', error => {
-        expect(error.message).toBe(`${ERROR_PREFIX}, every item in an "order" array should have an "item" property`);
+        errors.push(error.message);
     });
 
     await page.goto('/');
     await expect(page.locator(SELECTORS.HA_SIDEBAR)).toBeVisible();
+    expect(errors).toEqual(
+        expect.arrayContaining([
+            `${ERROR_PREFIX}, every item in an "order" array should have an "item" property`
+        ])
+    );
 
 });
 
 test('Validation: "item" property should be an string', async ({ page }) => {
+
+    const errors: string[] = [];
 
     await fulfillJson(page, {
         order: [
@@ -70,15 +93,22 @@ test('Validation: "item" property should be an string', async ({ page }) => {
     });
 
     page.on('pageerror', error => {
-        expect(error.message).toBe(`${ERROR_PREFIX} in dev, item property should be an string`);
+        errors.push(error.message);
     });
 
     await page.goto('/');
     await expect(page.locator(SELECTORS.HA_SIDEBAR)).toBeVisible();
+    expect(errors).toEqual(
+        expect.arrayContaining([
+            `${ERROR_PREFIX} in dev, item property should be an string`
+        ])
+    );
 
 });
 
 test('Validation: missing "href" in new item', async ({ page }) => {
+
+    const errors: string[] = [];
 
     await fulfillJson(page, {
         order: [
@@ -93,15 +123,22 @@ test('Validation: missing "href" in new item', async ({ page }) => {
     });
 
     page.on('pageerror', error => {
-        expect(error.message).toBe(`${ERROR_PREFIX} in dev, if you set "new_item" as "true", "href" property is necessary`);
+        errors.push(error.message);
     });
 
     await page.goto('/');
     await expect(page.locator(SELECTORS.HA_SIDEBAR)).toBeVisible();
+    expect(errors).toEqual(
+        expect.arrayContaining([
+            `${ERROR_PREFIX} in dev, if you set "new_item" as "true", "href" property is necessary`
+        ])
+    );
 
 });
 
 test('Validation: "href" in new item should be a string', async ({ page }) => {
+
+    const errors: string[] = [];
 
     await fulfillJson(page, {
         order: [
@@ -117,15 +154,22 @@ test('Validation: "href" in new item should be a string', async ({ page }) => {
     });
 
     page.on('pageerror', error => {
-        expect(error.message).toBe(`${ERROR_PREFIX} in dev, "href" property should be a string`);
+        errors.push(error.message);
     });
 
     await page.goto('/');
     await expect(page.locator(SELECTORS.HA_SIDEBAR)).toBeVisible();
+    expect(errors).toEqual(
+        expect.arrayContaining([
+            `${ERROR_PREFIX} in dev, "href" property should be a string`
+        ])
+    );
 
 });
 
 test('Validation: missing "icon" in new item', async ({ page }) => {
+
+    const errors: string[] = [];
 
     await fulfillJson(page, {
         order: [
@@ -141,15 +185,22 @@ test('Validation: missing "icon" in new item', async ({ page }) => {
     });
 
     page.on('pageerror', error => {
-        expect(error.message).toBe(`${ERROR_PREFIX} in dev, if you set "new_item" as "true", "icon" property is necessary`);
+        errors.push(error.message);
     });
 
     await page.goto('/');
     await expect(page.locator(SELECTORS.HA_SIDEBAR)).toBeVisible();
+    expect(errors).toEqual(
+        expect.arrayContaining([
+            `${ERROR_PREFIX} in dev, if you set "new_item" as "true", "icon" property is necessary`
+        ])
+    );
 
 });
 
 test('Validation: "icon" in new item should be a string', async ({ page }) => {
+
+    const errors: string[] = [];
 
     await fulfillJson(page, {
         order: [
@@ -166,15 +217,22 @@ test('Validation: "icon" in new item should be a string', async ({ page }) => {
     });
 
     page.on('pageerror', error => {
-        expect(error.message).toBe(`${ERROR_PREFIX} in dev, "icon" property should be a string`);
+        errors.push(error.message);
     });
 
     await page.goto('/');
     await expect(page.locator(SELECTORS.HA_SIDEBAR)).toBeVisible();
+    expect(errors).toEqual(
+        expect.arrayContaining([
+            `${ERROR_PREFIX} in dev, "icon" property should be a string`
+        ])
+    );
 
 });
 
 test('Validation: "exceptions" should be an array', async ({ page }) => {
+
+    const errors: string[] = [];
 
     await fulfillJson(page, {
         order: [],
@@ -182,15 +240,22 @@ test('Validation: "exceptions" should be an array', async ({ page }) => {
     });
 
     page.on('pageerror', error => {
-        expect(error.message).toBe(`${ERROR_PREFIX}, exceptions should be an array`);
+        errors.push(error.message);
     });
 
     await page.goto('/');
     await expect(page.locator(SELECTORS.HA_SIDEBAR)).toBeVisible();
+    expect(errors).toEqual(
+        expect.arrayContaining([
+            `${ERROR_PREFIX}, exceptions should be an array`
+        ])
+    );
 
 });
 
 test('Validation: "exceptions" without "order"', async ({ page }) => {
+
+    const errors: string[] = [];
 
     await fulfillJson(page, {
         order: [],
@@ -202,15 +267,22 @@ test('Validation: "exceptions" without "order"', async ({ page }) => {
     });
 
     page.on('pageerror', error => {
-        expect(error.message).toBe(`${ERROR_PREFIX}, every item in "exceptions" array should have an "order" property`);
+        errors.push(error.message);
     });
 
     await page.goto('/');
     await expect(page.locator(SELECTORS.HA_SIDEBAR)).toBeVisible();
+    expect(errors).toEqual(
+        expect.arrayContaining([
+            `${ERROR_PREFIX}, every item in "exceptions" array should have an "order" property`
+        ])
+    );
 
 });
 
 test('Validation: "exceptions" with malformed "user"', async ({ page }) => {
+
+    const errors: string[] = [];
 
     await fulfillJson(page, {
         order: [],
@@ -223,15 +295,22 @@ test('Validation: "exceptions" with malformed "user"', async ({ page }) => {
     });
 
     page.on('pageerror', error => {
-        expect(error.message).toBe(`${ERROR_PREFIX}, exceptions "user" property should be a string or an array of strings`);
+        errors.push(error.message);
     });
 
     await page.goto('/');
     await expect(page.locator(SELECTORS.HA_SIDEBAR)).toBeVisible();
+    expect(errors).toEqual(
+        expect.arrayContaining([
+            `${ERROR_PREFIX}, exceptions "user" property should be a string or an array of strings`
+        ])
+    );
 
 });
 
 test('Validation: "exceptions" with malformed "not_user"', async ({ page }) => {
+
+    const errors: string[] = [];
 
     await fulfillJson(page, {
         order: [],
@@ -244,15 +323,22 @@ test('Validation: "exceptions" with malformed "not_user"', async ({ page }) => {
     });
 
     page.on('pageerror', error => {
-        expect(error.message).toBe(`${ERROR_PREFIX}, exceptions "not_user" property should be a string or an array of strings`);
+        errors.push(error.message);
     });
 
     await page.goto('/');
     await expect(page.locator(SELECTORS.HA_SIDEBAR)).toBeVisible();
+    expect(errors).toEqual(
+        expect.arrayContaining([
+            `${ERROR_PREFIX}, exceptions "not_user" property should be a string or an array of strings`
+        ])
+    );
 
 });
 
 test('Validation: "exceptions" with malformed "device"', async ({ page }) => {
+
+    const errors: string[] = [];
 
     await fulfillJson(page, {
         order: [],
@@ -265,15 +351,22 @@ test('Validation: "exceptions" with malformed "device"', async ({ page }) => {
     });
 
     page.on('pageerror', error => {
-        expect(error.message).toBe(`${ERROR_PREFIX}, exceptions "device" property should be a string or an array of strings`);
+        errors.push(error.message);
     });
 
     await page.goto('/');
     await expect(page.locator(SELECTORS.HA_SIDEBAR)).toBeVisible();
+    expect(errors).toEqual(
+        expect.arrayContaining([
+            `${ERROR_PREFIX}, exceptions "device" property should be a string or an array of strings`
+        ])
+    );
 
 });
 
 test('Validation: "exceptions" with malformed "not_device"', async ({ page }) => {
+
+    const errors: string[] = [];
 
     await fulfillJson(page, {
         order: [],
@@ -286,15 +379,22 @@ test('Validation: "exceptions" with malformed "not_device"', async ({ page }) =>
     });
 
     page.on('pageerror', error => {
-        expect(error.message).toBe(`${ERROR_PREFIX}, exceptions "not_device" property should be a string or an array of strings`);
+        errors.push(error.message);
     });
 
     await page.goto('/');
     await expect(page.locator(SELECTORS.HA_SIDEBAR)).toBeVisible();
+    expect(errors).toEqual(
+        expect.arrayContaining([
+            `${ERROR_PREFIX}, exceptions "not_device" property should be a string or an array of strings`
+        ])
+    );
 
 });
 
 test('Validation: "exceptions" with "user" and "no_uer"', async ({ page }) => {
+
+    const errors: string[] = [];
 
     await fulfillJson(page, {
         order: [],
@@ -308,15 +408,22 @@ test('Validation: "exceptions" with "user" and "no_uer"', async ({ page }) => {
     });
 
     page.on('pageerror', error => {
-        expect(error.message).toBe(`${ERROR_PREFIX}, exceptions "user" and "not_user" properties cannot be used together`);
+        errors.push(error.message);
     });
 
     await page.goto('/');
     await expect(page.locator(SELECTORS.HA_SIDEBAR)).toBeVisible();
+    expect(errors).toEqual(
+        expect.arrayContaining([
+            `${ERROR_PREFIX}, exceptions "user" and "not_user" properties cannot be used together`
+        ])
+    );
 
 });
 
 test('Validation: "exceptions" with "device" and "not_device"', async ({ page }) => {
+
+    const errors: string[] = [];
 
     await fulfillJson(page, {
         order: [],
@@ -330,15 +437,22 @@ test('Validation: "exceptions" with "device" and "not_device"', async ({ page })
     });
 
     page.on('pageerror', error => {
-        expect(error.message).toBe(`${ERROR_PREFIX}, exceptions "device" and "not_device" properties cannot be used together`);
+        errors.push(error.message);
     });
 
     await page.goto('/');
     await expect(page.locator(SELECTORS.HA_SIDEBAR)).toBeVisible();
+    expect(errors).toEqual(
+        expect.arrayContaining([
+            `${ERROR_PREFIX}, exceptions "device" and "not_device" properties cannot be used together`
+        ])
+    );
 
 });
 
 test('Validation: "exceptions" with invalid "order"', async ({ page }) => {
+
+    const errors: string[] = [];
 
     await fulfillJson(page, {
         order: [],
@@ -358,10 +472,15 @@ test('Validation: "exceptions" with invalid "order"', async ({ page }) => {
     });
 
     page.on('pageerror', error => {
-        expect(error.message).toBe(`${ERROR_PREFIX}, every item in an "order" array should have an "item" property`);
+        errors.push(error.message);
     });
 
     await page.goto('/');
     await expect(page.locator(SELECTORS.HA_SIDEBAR)).toBeVisible();
+    expect(errors).toEqual(
+        expect.arrayContaining([
+            `${ERROR_PREFIX}, every item in an "order" array should have an "item" property`
+        ])
+    );
 
 });


### PR DESCRIPTION
Changing the way of test for errors because if fr some reason Home Assistant throws a warning or an error it will fail to match the one that we are trying to match. Now it chacks if the desired error is inside of an array of errors generated from the errors throwed on page load.