### PR TITLE
Update the package home-assistant-javascript-templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "home-assistant-javascript-templates": "^3.0.1",
+    "home-assistant-javascript-templates": "^3.1.0",
     "home-assistant-query-selector": "^4.2.0",
     "js-yaml": "^4.1.0"
   }

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -45,6 +45,5 @@ export enum EVENT {
 }
 
 export const TEMPLATE_REG = /^\s*\[\[\[([\s\S]+)\]\]\]\s*$/;
-export const ENTITIES_REGEXP = /(?:^|\W)(?:(?:states|is_state|state_attr|is_state_attr|has_value)\s*\(\s*['"]\s*([a-z0-9_.]+)\s*['"]|states\s*\[\s*["']\s*([a-z0-9_]+)\s*["']|states\.([a-z0-9_]+))/g;
 export const CSS_CLEANER_REGEXP = /(\s*)([\w-]+\s*:\s*[^;]+;?|\})(\s*)/g;
 export const DOMAIN_REGEXP = /^([a-z_]+)[\w.]*$/;

--- a/tests/05 - interactions.spec.ts
+++ b/tests/05 - interactions.spec.ts
@@ -13,18 +13,14 @@ test.beforeAll(async () => {
   await haConfigRequest(CONFIG_FILES.BASIC);
 });
 
-const visitHome = async (page: Page): Promise<void> => {
+test('Clicking on items with the same root path should select the proper item', async ({ page }) => {
+
   await page.goto('/');
   await expect(page.locator(SELECTORS.HA_SIDEBAR)).toBeVisible();
   await expect(page.locator(SELECTORS.HUI_VIEW)).toBeVisible();
   await expect(page).toHaveScreenshot('01-sidebar.png', {
     clip: SIDEBAR_CLIP
   });
-};
-
-test('Clicking on items with the same root path should select the proper item', async ({ page }) => {
-
-  await visitHome(page);
 
   await page.locator(SELECTORS.SIDEBAR_ITEMS.CONFIG).click();
 
@@ -100,7 +96,8 @@ test('Do not move the clicked item outside the viewport', async ({ page }) => {
     }
   });
 
-  await page.locator(SELECTORS.SIDEBAR_ITEMS.INTEGRATIONS).click({ delay: 50 });
+  await page.locator(SELECTORS.SIDEBAR_ITEMS.INTEGRATIONS).click({ delay: 150 });
+  await page.waitForTimeout(100);
 
   await expect(page.locator(SELECTORS.SIDEBAR_ITEMS.INTEGRATIONS)).toBeInViewport();
 

--- a/tests/08 - validator-errors.spec.ts
+++ b/tests/08 - validator-errors.spec.ts
@@ -392,7 +392,7 @@ test('Validation: "exceptions" with malformed "not_device"', async ({ page }) =>
 
 });
 
-test('Validation: "exceptions" with "user" and "no_uer"', async ({ page }) => {
+test('Validation: "exceptions" with "user" and "no_user"', async ({ page }) => {
 
     const errors: string[] = [];
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -861,10 +861,10 @@ helpertypes@^0.0.19:
   resolved "https://registry.yarnpkg.com/helpertypes/-/helpertypes-0.0.19.tgz#6f8cb18e4e1fad73dc103b98e624ac85cb06a720"
   integrity sha512-J00e55zffgi3yVnUp0UdbMztNkr2PnizEkOe9URNohnrNhW5X0QpegkuLpOmFQInpi93Nb8MCjQRHAiCDF42NQ==
 
-home-assistant-javascript-templates@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/home-assistant-javascript-templates/-/home-assistant-javascript-templates-3.0.1.tgz#1ba1e3e5d6634f9ed7d80a6abbf19c7b016ad3b9"
-  integrity sha512-dVzYFBlJdgDyEh+AfJ061Z9n8vz1J4jlWK9jPPK+hIlekWuhYuEVUTs+ZH51IPxx6E+iuANW8jZ7X131Kvkk7w==
+home-assistant-javascript-templates@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/home-assistant-javascript-templates/-/home-assistant-javascript-templates-3.1.0.tgz#06db0b60c437b79df12956b0df76ff39076d7528"
+  integrity sha512-p+za9mtntAVyUHdCSwVp9sdP+1AIBWbelBZzNcBswydHG9mmMN5zcjr4EjM1NVQW4yYaEnT4ftjJS/RWYTlf4Q==
 
 home-assistant-query-selector@^4.2.0:
   version "4.2.0"


### PR DESCRIPTION
This pull request updates the package `home-assistant-javascript-templates` and starts using its `tracked` feature intead of extracting the entities and domains used in a `JavaScript` template using regular expressions, something that will not capture dynamicllay used entities.