### PR TITLE
Change console.info colors

### DIFF
--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -55,8 +55,8 @@ const flatConfigOrder = (order: ConfigOrder[]): ConfigOrder[] => {
 export const logVersionToConsole = () => {
     console.info(
         `%c≡ ${NAMESPACE.toUpperCase()} (%CONFIG%)%cv${version}`,
-        'font-weight: bold; color: #666666; padding: 2px;',
-        'font-weight: normal; color: #212121; padding: 2px'
+        'font-weight: bold; background: #EEEEEE; color: #666666; padding: 2px 5px;',
+        'font-weight: normal; background: #E87A24; color: #FFFFFF; padding: 2px 5px'
     );
 };
 


### PR DESCRIPTION
This pull request changes the `console.info` colors to make it visible also in dark mode.

| Before | After |
| ------ | ----- |
| <img width="255" alt="image" src="https://github.com/elchininet/custom-sidebar/assets/3728220/032b5947-ed51-4347-aaaa-514b6cded1e2"> | <img width="267" alt="image" src="https://github.com/elchininet/custom-sidebar/assets/3728220/83127034-0dff-4142-ba07-34e7abdaffba"> |
| <img width="240" alt="image" src="https://github.com/elchininet/custom-sidebar/assets/3728220/7fea80ec-0330-4276-9b51-57c87c0c30d9"> | <img width="256" alt="image" src="https://github.com/elchininet/custom-sidebar/assets/3728220/768ab521-d70b-46d8-9c01-0218eed77f74"> |