### PR TITLE
Add a new option to avoid sidebar edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Add a file named `sidebar-config.json` or `sidebar-config.yaml` into your `<conf
 | ------------------ | ---------------------------------- | -------- | ----------- |
 | order              | Array of [items](#item-properties) | true     | List of items to process |
 | title<sup>\*</sup> | String                             | false    | Custom title to replace the `Home Assistant` title |
+| sidebar_editable   | Boolean                            | false    | If it is set to `false`, long press on the sidebar title will be ignored and the button to edit the sidebar in the profile panel will be disabled |
 
 #### Item properties
 

--- a/README.md
+++ b/README.md
@@ -106,26 +106,26 @@ Add a file named `sidebar-config.json` or `sidebar-config.yaml` into your `<conf
 
 | Property           | Type                               | Required | Description |
 | ------------------ | ---------------------------------- | -------- | ----------- |
-| order              | Array of [items](#item-properties) | true     | List of items to process |
-| title<sup>\*</sup> | String                             | false    | Custom title to replace the `Home Assistant` title |
-| sidebar_editable   | Boolean                            | false    | If it is set to `false`, long press on the sidebar title will be ignored and the button to edit the sidebar in the profile panel will be disabled |
+| order              | Array of [items](#item-properties) | yes      | List of items to process |
+| title<sup>\*</sup> | String                             | no       | Custom title to replace the `Home Assistant` title |
+| sidebar_editable   | Boolean                            | no       | If it is set to `false`, long press on the sidebar title will be ignored and the button to edit the sidebar in the profile panel will be disabled |
 
 #### Item properties
 
 | Property                  | Type    | Required  | Description |
 | ------------------------- | ------- | --------- | ----------- |
-| item                      | String  | true      | This is a string that will be used to match each sidebar item by its text, its `data-panel` attribute or its `href`. If the `exact` property is not set, it is case insensitive and it can be a substring such as `developer` instead of `Developer Tools` or `KITCHEN` instead of `kitchen-lights`. |
-| match                     | String  | false     | This property will define which string will be used to match the `item` property. It has three possible values "text" (default) to match the text content of the element, "data-panel" to match the `data-panel` attribute of the element, or "href", to match the `href` attribute of the element |
-| exact                     | Boolean | false     | Specifies whether the `item` string match should be an exact match (`true`) or not (`false`). |
-| name<sup>\*</sup>         | String  | false     | Changes the name of the sidebar item |
-| notification<sup>\*</sup> | String  | false     | Add a notification badge to the sidebar item |
-| order                     | Number  | false     | Sets the order number of the sidebar item |
-| bottom                    | Boolean | false     | Setting this property to `true` will group the item with the bottom items (Configuration, Developer Tools, etc)         |
-| hide                      | Boolean | false     | Setting this property to `true` will hide the sidebar item |
-| href                      | String  | false     | Specifies the `href` of the sidebar item |
-| target                    | String  | false     | Specifies the [target property] of the sidebar item |
-| icon                      | String  | false     | Specifies the icon of the sidebar item |
-| new_item                  | Boolean | false     | Set this property to `true` to create a new item in the sidebar. **Using this option makes `href` and `icon` required properties** |
+| item                      | String  | yes       | This is a string that will be used to match each sidebar item by its text, its `data-panel` attribute or its `href`. If the `exact` property is not set, it is case insensitive and it can be a substring such as `developer` instead of `Developer Tools` or `KITCHEN` instead of `kitchen-lights`. |
+| match                     | String  | no        | This property will define which string will be used to match the `item` property. It has three possible values "text" (default) to match the text content of the element, "data-panel" to match the `data-panel` attribute of the element, or "href", to match the `href` attribute of the element |
+| exact                     | Boolean | no        | Specifies whether the `item` string match should be an exact match (`true`) or not (`false`). |
+| name<sup>\*</sup>         | String  | no        | Changes the name of the sidebar item |
+| notification<sup>\*</sup> | String  | no        | Add a notification badge to the sidebar item |
+| order                     | Number  | no        | Sets the order number of the sidebar item |
+| bottom                    | Boolean | no        | Setting this property to `true` will group the item with the bottom items (Configuration, Developer Tools, etc)         |
+| hide                      | Boolean | no        | Setting this property to `true` will hide the sidebar item |
+| href                      | String  | no        | Specifies the `href` of the sidebar item |
+| target                    | String  | no        | Specifies the [target property] of the sidebar item |
+| icon                      | String  | no        | Specifies the icon of the sidebar item |
+| new_item                  | Boolean | no        | Set this property to `true` to create a new item in the sidebar. **Using this option makes `href` and `icon` required properties** |
 
 >\* These options and item properties allow [JavaScript templates](#javascript-templates).
 
@@ -194,12 +194,12 @@ You can define user-specific order using exceptions feature. Exceptions can be u
 
 | Property   | Type    | Required | Description |
 | ---------- | ------- | -------- | ----------- |
-| order      | Array of [items](#item-properties) | true   | Defines the sidebar items order |
-| base_order | Boolean | false   | If true, the `order` property will be merged with the root `config.order` array |
-| user       | String or String[] | false   | Home Assistant user name(s) you would like to display this order for |
-| not_user   | String or String[] | false   | Home Assistant user name(s) you wouldn't like to display this order for |
-| device     | String or String[] | false   | Device(s) you would like to display this order for. E.g. ipad, iphone, macintosh, windows, android (it uses the device's [user-agent]) |
-| not_device | String or String[] | false   | Device(s) you wouldn't like to display this order for. E.g. ipad, iphone, macintosh, windows, android (it uses the device's [user-agent]) |
+| order      | Array of [items](#item-properties) | yes   | Defines the sidebar items order |
+| base_order | Boolean | no       | If true, the `order` property will be merged with the root `config.order` array |
+| user       | String or String[] | no          | Home Assistant user name(s) you would like to display this order for |
+| not_user   | String or String[] | no          | Home Assistant user name(s) you wouldn't like to display this order for |
+| device     | String or String[] | no          | Device(s) you would like to display this order for. E.g. ipad, iphone, macintosh, windows, android (it uses the device's [user-agent]) |
+| not_device | String or String[] | no          | Device(s) you wouldn't like to display this order for. E.g. ipad, iphone, macintosh, windows, android (it uses the device's [user-agent]) |
 
 Short example in `JSON` format:
 

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -36,12 +36,14 @@ export enum ATTRIBUTE {
     WITH_NOTIFICATION = 'data-notification',
     ARIA_SELECTED = 'aria-selected',
     ARIA_DISABLED = 'aria-disabled',
+    DISABLED = 'disabled',
     HREF = 'href',
     STYLE = 'style'
 }
 
 export enum EVENT {
-    MOUSEDOWN = 'mousedown'
+    MOUSEDOWN = 'mousedown',
+    HASS_EDIT_SIDEBAR = 'hass-edit-sidebar'
 }
 
 export const TEMPLATE_REG = /^\s*\[\[\[([\s\S]+)\]\]\]\s*$/;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -87,6 +87,7 @@ export interface Config {
     title?: string;
     order: ConfigOrder[];
     exceptions?: ConfigException[];
+    sidebar_editable?: boolean;
 }
 
 export type SuscriberEvent = {

--- a/tests/02 - exceptions-options.spec.ts
+++ b/tests/02 - exceptions-options.spec.ts
@@ -5,7 +5,7 @@ import {
   CONFIG_FILES,
   SIDEBAR_CLIP
 } from './constants';
-import { haConfigRequest, addJsonExceptionsRoute } from './utilities';
+import { haConfigRequest, addJsonExtendedRoute } from './utilities';
 
 test.beforeAll(async () => {
   await haConfigRequest(CONFIG_FILES.BASIC);
@@ -19,19 +19,21 @@ const pageVisit = async (page: Page): Promise<void> => {
 
 test('Exceptions item override', async ({ page }) => {
 
-  await addJsonExceptionsRoute(page, [
-    {
-      user: 'Test',
-      base_order: true,
-      order: [
-        {
-          item: 'developer tools',
-          bottom: true,
-          order: 9
-        }
-      ]
-    }
-  ]);
+  await addJsonExtendedRoute(page, {
+    exceptions: [
+      {
+        user: 'Test',
+        base_order: true,
+        order: [
+          {
+            item: 'developer tools',
+            bottom: true,
+            order: 9
+          }
+        ]
+      }
+    ]
+  });
 
   await pageVisit(page);
 
@@ -43,22 +45,24 @@ test('Exceptions item override', async ({ page }) => {
 
 test('Exceptions new_item override', async ({ page }) => {
 
-  await addJsonExceptionsRoute(page, [
-    {
-      user: 'Test',
-      base_order: true,
-      order: [
-        {
-          new_item: true,
-          item: 'Google',
-          name: 'Search',
-          icon: 'mdi:web',
-          href: 'https://google.com',
-          order: -1
-        }
-      ]
-    }
-  ]);
+  await addJsonExtendedRoute(page, {
+    exceptions: [
+      {
+        user: 'Test',
+        base_order: true,
+        order: [
+          {
+            new_item: true,
+            item: 'Google',
+            name: 'Search',
+            icon: 'mdi:web',
+            href: 'https://google.com',
+            order: -1
+          }
+        ]
+      }
+    ]
+  });
 
   await pageVisit(page);
 
@@ -93,12 +97,14 @@ test.describe('Exceptions matchers', async () => {
 
   test('Exceptions user', async ({ page }) => {
 
-    await addJsonExceptionsRoute(page, [
-      {
-        user: 'Test',
-        ...json
-      }
-    ]);
+    await addJsonExtendedRoute(page, {
+      exceptions: [
+        {
+          user: 'Test',
+          ...json
+        }
+      ]
+    });
   
     await pageVisit(page);
   
@@ -110,12 +116,14 @@ test.describe('Exceptions matchers', async () => {
 
   test('Exceptions user as array', async ({ page }) => {
 
-    await addJsonExceptionsRoute(page, [
-      {
-        user: ['ElChiniNet', 'Test', 'Palaus'],
-        ...json
-      }
-    ]);
+    await addJsonExtendedRoute(page, {
+      exceptions: [
+        {
+          user: ['ElChiniNet', 'Test', 'Palaus'],
+          ...json
+        }
+      ]
+    });
   
     await pageVisit(page);
   
@@ -127,12 +135,14 @@ test.describe('Exceptions matchers', async () => {
   
   test('Exceptions not_user', async ({ page }) => {
   
-    await addJsonExceptionsRoute(page, [
-      {
-        not_user: 'ElChiniNet',
-        ...json
-      }
-    ]);
+    await addJsonExtendedRoute(page, {
+      exceptions: [
+        {
+          not_user: 'ElChiniNet',
+          ...json
+        }
+      ]
+    });
   
     await pageVisit(page);
   
@@ -144,12 +154,14 @@ test.describe('Exceptions matchers', async () => {
 
   test('Exceptions not_user as an array', async ({ page }) => {
   
-    await addJsonExceptionsRoute(page, [
-      {
-        not_user: ['ElChiniNet', 'Palaus'],
-        ...json
-      }
-    ]);
+    await addJsonExtendedRoute(page, {
+      exceptions: [
+        {
+          not_user: ['ElChiniNet', 'Palaus'],
+          ...json
+        }
+      ]
+    });
   
     await pageVisit(page);
   
@@ -161,12 +173,14 @@ test.describe('Exceptions matchers', async () => {
 
   test('Exceptions device', async ({ page }) => {
   
-    await addJsonExceptionsRoute(page, [
-      {
-        device: 'Chrome',
-        ...json
-      }
-    ]);
+    await addJsonExtendedRoute(page, {
+      exceptions: [
+        {
+          device: 'Chrome',
+          ...json
+        }
+      ]
+    });
   
     await pageVisit(page);
   
@@ -178,12 +192,14 @@ test.describe('Exceptions matchers', async () => {
 
   test('Exceptions device as an array', async ({ page }) => {
   
-    await addJsonExceptionsRoute(page, [
-      {
-        device: ['Android', 'Chrome', 'iPad'],
-        ...json
-      }
-    ]);
+    await addJsonExtendedRoute(page, {
+      exceptions: [
+        {
+          device: ['Android', 'Chrome', 'iPad'],
+          ...json
+        }
+      ]
+    });
   
     await pageVisit(page);
   
@@ -195,12 +211,14 @@ test.describe('Exceptions matchers', async () => {
 
   test('Exceptions not_device', async ({ page }) => {
   
-    await addJsonExceptionsRoute(page, [
-      {
-        not_device: 'iPad',
-        ...json
-      }
-    ]);
+    await addJsonExtendedRoute(page, {
+      exceptions: [
+        {
+          not_device: 'iPad',
+          ...json
+        }
+      ]
+    });
   
     await pageVisit(page);
   
@@ -212,12 +230,14 @@ test.describe('Exceptions matchers', async () => {
 
   test('Exceptions not_device as an array', async ({ page }) => {
   
-    await addJsonExceptionsRoute(page, [
-      {
-        not_device: ['iPad', 'Android'],
-        ...json
-      }
-    ]);
+    await addJsonExtendedRoute(page, {
+      exceptions: [
+        {
+          not_device: ['iPad', 'Android'],
+          ...json
+        }
+      ]
+    });
   
     await pageVisit(page);
   
@@ -229,24 +249,26 @@ test.describe('Exceptions matchers', async () => {
 
   test('Exceptions do not extend', async ({ page }) => {
   
-    await addJsonExceptionsRoute(page, [
-      {
-        user: 'Test',
-        order: [
-          ...json.order,
-          {
-            item: 'dev',
-            bottom: true
-          },
-          {
-            item: 'config',
-            match: 'data-panel',
-            bottom: true
-          }
-        ],
-        base_order: false
-      }
-    ]);
+    await addJsonExtendedRoute(page, {
+      exceptions: [
+        {
+          user: 'Test',
+          order: [
+            ...json.order,
+            {
+              item: 'dev',
+              bottom: true
+            },
+            {
+              item: 'config',
+              match: 'data-panel',
+              bottom: true
+            }
+          ],
+          base_order: false
+        }
+      ]
+    });
   
     await pageVisit(page);
 

--- a/tests/05 - interactions.spec.ts
+++ b/tests/05 - interactions.spec.ts
@@ -3,9 +3,10 @@ import { Page } from '@playwright/test';
 import {
   SELECTORS,
   CONFIG_FILES,
-  SIDEBAR_CLIP
+  SIDEBAR_CLIP,
+  ATTRIBUTES
 } from './constants';
-import { haConfigRequest } from './utilities';
+import { haConfigRequest, addJsonExtendedRoute } from './utilities';
 
 const SELECTED_CLASSNAME = /(^|\s)iron-selected(\s|$)/;
 
@@ -13,36 +14,45 @@ test.beforeAll(async () => {
   await haConfigRequest(CONFIG_FILES.BASIC);
 });
 
-test('Clicking on items with the same root path should select the proper item', async ({ page }) => {
-
+const visitHome = async (page: Page): Promise<void> => {
   await page.goto('/');
   await expect(page.locator(SELECTORS.HA_SIDEBAR)).toBeVisible();
   await expect(page.locator(SELECTORS.HUI_VIEW)).toBeVisible();
   await expect(page).toHaveScreenshot('01-sidebar.png', {
     clip: SIDEBAR_CLIP
   });
+};
 
-  await page.locator(SELECTORS.SIDEBAR_ITEMS.CONFIG).click();
+test('Clicking on items with the same root path should select the proper item', async ({ page }) => {
 
-  await expect(page.locator(SELECTORS.SIDEBAR_ITEMS.CONFIG)).toHaveClass(SELECTED_CLASSNAME);
-  await expect(page.locator(SELECTORS.SIDEBAR_ITEMS.INTEGRATIONS)).not.toHaveClass(SELECTED_CLASSNAME);
-  await expect(page.locator(SELECTORS.SIDEBAR_ITEMS.ENTITIES)).not.toHaveClass(SELECTED_CLASSNAME);
-  await expect(page.locator(SELECTORS.SIDEBAR_ITEMS.AUTOMATIONS)).not.toHaveClass(SELECTED_CLASSNAME);
+  await visitHome(page);
+  await page.waitForTimeout(600);
 
   await page.locator(SELECTORS.SIDEBAR_ITEMS.INTEGRATIONS).click();
+  await page.waitForTimeout(600);
 
   await expect(page.locator(SELECTORS.SIDEBAR_ITEMS.INTEGRATIONS)).toHaveClass(SELECTED_CLASSNAME);
   await expect(page.locator(SELECTORS.SIDEBAR_ITEMS.CONFIG)).not.toHaveClass(SELECTED_CLASSNAME);
-
+  
   await page.locator(SELECTORS.SIDEBAR_ITEMS.ENTITIES).click();
+  await page.waitForTimeout(600);
 
   await expect(page.locator(SELECTORS.SIDEBAR_ITEMS.ENTITIES)).toHaveClass(SELECTED_CLASSNAME);
   await expect(page.locator(SELECTORS.SIDEBAR_ITEMS.CONFIG)).not.toHaveClass(SELECTED_CLASSNAME);
 
   await page.locator(SELECTORS.SIDEBAR_ITEMS.AUTOMATIONS).click();
+  await page.waitForTimeout(600);
 
   await expect(page.locator(SELECTORS.SIDEBAR_ITEMS.AUTOMATIONS)).toHaveClass(SELECTED_CLASSNAME);
   await expect(page.locator(SELECTORS.SIDEBAR_ITEMS.CONFIG)).not.toHaveClass(SELECTED_CLASSNAME);
+
+  await page.locator(SELECTORS.SIDEBAR_ITEMS.CONFIG).click();
+  await page.waitForTimeout(600);
+
+  await expect(page.locator(SELECTORS.SIDEBAR_ITEMS.CONFIG)).toHaveClass(SELECTED_CLASSNAME);
+  await expect(page.locator(SELECTORS.SIDEBAR_ITEMS.INTEGRATIONS)).not.toHaveClass(SELECTED_CLASSNAME);
+  await expect(page.locator(SELECTORS.SIDEBAR_ITEMS.ENTITIES)).not.toHaveClass(SELECTED_CLASSNAME);
+  await expect(page.locator(SELECTORS.SIDEBAR_ITEMS.AUTOMATIONS)).not.toHaveClass(SELECTED_CLASSNAME);
 
 });
 
@@ -105,5 +115,58 @@ test('Do not move the clicked item outside the viewport', async ({ page }) => {
   expect(
     await page.locator(SELECTORS.PAPER_LIST_BOX).evaluate(element => element.scrollTop)
   ).toBe(scrollTopStart);
+
+});
+
+test('By default it should be possible to edit the sidebar', async ({ page }) => {
+
+  await visitHome(page);
+
+  await page.locator(SELECTORS.TITLE).click({ delay: 1000 });
+
+  await expect(page.locator(SELECTORS.TITLE)).not.toBeVisible();
+  await expect(page.locator(SELECTORS.SIDEBAR_EDIT_BUTTON)).toBeVisible();
+
+  await page.goto('/profile');
+
+  await expect(page.locator(SELECTORS.PROFILE_EDIT_BUTTON)).not.toHaveAttribute(ATTRIBUTES.DISABLED);
+
+});
+
+test('If sidebar_editable is set to true it should be possible to edit the sidebar', async ({ page }) => {
+
+  await visitHome(page);
+
+  await addJsonExtendedRoute(page, {
+    sidebar_editable: true
+  });
+
+  await page.locator(SELECTORS.TITLE).click({ delay: 1000 });
+
+  await expect(page.locator(SELECTORS.TITLE)).not.toBeVisible();
+  await expect(page.locator(SELECTORS.SIDEBAR_EDIT_BUTTON)).toBeVisible();
+
+  await page.goto('/profile');
+
+  await expect(page.locator(SELECTORS.PROFILE_EDIT_BUTTON)).not.toHaveAttribute(ATTRIBUTES.DISABLED);
+
+});
+
+test('If sidebar_editable is set to false it should not be possible to edit the sidebar', async ({ page }) => {
+
+  await addJsonExtendedRoute(page, {
+    sidebar_editable: false
+  });
+
+  await visitHome(page);
+
+  await page.locator(SELECTORS.TITLE).click({ delay: 1000 });
+
+  await expect(page.locator(SELECTORS.TITLE)).toBeVisible();
+  await expect(page.locator(SELECTORS.SIDEBAR_EDIT_BUTTON)).not.toBeVisible();
+
+  await page.goto('/profile');
+
+  await expect(page.locator(SELECTORS.PROFILE_EDIT_BUTTON)).toHaveAttribute(ATTRIBUTES.DISABLED);
 
 });

--- a/tests/constants.ts
+++ b/tests/constants.ts
@@ -8,6 +8,8 @@ const getSidebarItemSelector = (panel: string): string => {
 
 export const SELECTORS = {
     TITLE: '.menu .title',
+    SIDEBAR_EDIT_BUTTON: '.menu mwc-button',
+    PROFILE_EDIT_BUTTON: '.content > ha-card ha-settings-row > mwc-button',
     HA_SIDEBAR: 'ha-sidebar',
     HUI_VIEW: 'hui-view',
     PAPER_LIST_BOX: 'paper-listbox',
@@ -27,6 +29,10 @@ export const SELECTORS = {
         AUTOMATIONS: getSidebarItemSelector('automations'),
         HIDDEN: getSidebarItemSelector('hidden')
     }
+};
+
+export const ATTRIBUTES = {
+    DISABLED: 'disabled'
 };
 
 export const CONFIG_FILES = {

--- a/tests/utilities.ts
+++ b/tests/utilities.ts
@@ -69,17 +69,17 @@ export const haSelectStateRequest = async (state: 1 | 2 | 3, retries = 0) => {
 	});
 };
 
-export const addJsonExceptionsRoute = async (page: Page, exceptions: Record<string, unknown>[]): Promise<void> => {
+export const addJsonExtendedRoute = async (page: Page, options: Record<string, unknown>): Promise<void> => {
 	await page.route(JSON_PATH, async route => {
 		const response = await route.fetch();
 		const json = await response.json();
-		const jsonWithExceptions = {
+		const jsonExtended = {
 			...json,
-			exceptions
+			...options
 		};
 		await route.fulfill({
 			response,
-			json: jsonWithExceptions
+			json: jsonExtended
 		});
 	});
 };


### PR DESCRIPTION
This pull request adds a new option to avoid editing the sidebar, either making a long press on the sidebar title or going to the profile panel and click on the edit sidebar button.

As this is a `JavaScript` plugin it is impossible to change `Home Assistant` default funcionality, but it is possible to block `JavaScript` events and the order to edit the sidebar is done through an event. So blocking these options should be enough to avoid modifying a sidebar that was already modified by the plugin.

### Configuration options

| Property           | Type                               | Required | Description |
| ------------------ | ---------------------------------- | -------- | ----------- |
| sidebar_editable   | Boolean                            | no       | If it is set to `false`, long press on the sidebar title will be ignored and the button to edit the sidebar in the profile panel will be disabled |