### PR TITLE
Improve accesibility making leyboard navigation to work following the CSS order

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -21,12 +21,16 @@ export enum SELECTOR {
     SPACER = '.spacer',
     ITEM_TEXT = '.item-text',
     NOTIFICATION_BADGE = '.notification-badge',
-    NOTIFICATIONS_BADGE_COLLAPSED = '.notification-badge-collapsed'
+    NOTIFICATIONS_BADGE_COLLAPSED = '.notification-badge-collapsed',
+    EDIT_SIDEBAR_BUTTON = 'ha-panel-profile$ ha-settings-row mwc-button',
+    SIDEBAR_NOTIFICATIONS = '.notifications',
+    PROFILE = '.profile'
 }
 
 export enum CLASS {
     NOTIFICATIONS_BADGE = 'notification-badge',
-    NOTIFICATIONS_BADGE_COLLAPSED = 'notification-badge-collapsed'
+    NOTIFICATIONS_BADGE_COLLAPSED = 'notification-badge-collapsed',
+    IRON_SELECTED = 'iron-selected'
 }
 
 export enum ATTRIBUTE {
@@ -43,7 +47,14 @@ export enum ATTRIBUTE {
 
 export enum EVENT {
     MOUSEDOWN = 'mousedown',
+    KEYDOWN = 'keydown',
     HASS_EDIT_SIDEBAR = 'hass-edit-sidebar'
+}
+
+export enum KEY {
+    ARROW_DOWN = 'ArrowDown',
+    ARROW_UP = 'ArrowUp',
+    ENTER = 'Enter'
 }
 
 export const TEMPLATE_REG = /^\s*\[\[\[([\s\S]+)\]\]\]\s*$/;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -49,9 +49,7 @@ export enum ATTRIBUTE {
 export enum EVENT {
     MOUSEDOWN = 'mousedown',
     KEYDOWN = 'keydown',
-    HASS_EDIT_SIDEBAR = 'hass-edit-sidebar',
-    FOCUSIN = 'focusin',
-    FOCUSOUT = 'focusout'
+    HASS_EDIT_SIDEBAR = 'hass-edit-sidebar'
 }
 
 export enum KEY {

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -11,7 +11,8 @@ export enum ELEMENT {
     PAPER_LISTBOX = 'paper-listbox',
     PAPER_ICON_ITEM = 'paper-icon-item',
     HA_SVG_ICON = 'ha-svg-icon',
-    HA_ICON = 'ha-icon'
+    HA_ICON = 'ha-icon',
+    HA_ICON_BUTTON = 'ha-icon-button'
 }
 
 export enum SELECTOR {
@@ -48,14 +49,30 @@ export enum ATTRIBUTE {
 export enum EVENT {
     MOUSEDOWN = 'mousedown',
     KEYDOWN = 'keydown',
-    HASS_EDIT_SIDEBAR = 'hass-edit-sidebar'
+    HASS_EDIT_SIDEBAR = 'hass-edit-sidebar',
+    FOCUSIN = 'focusin',
+    FOCUSOUT = 'focusout'
 }
 
 export enum KEY {
     ARROW_DOWN = 'ArrowDown',
     ARROW_UP = 'ArrowUp',
-    ENTER = 'Enter'
+    ENTER = 'Enter',
+    TAB = 'Tab'
 }
+
+export enum NODE_NAME {
+    PAPER_ICON_ITEM = 'PAPER-ICON-ITEM',
+    A = 'A'
+}
+
+export const CHECK_FOCUSED_SHADOW_ROOT = [
+    'HOME-ASSISTANT',
+    'HOME-ASSISTANT-MAIN',
+    'HA-SIDEBAR'
+];
+
+export const PROFILE_PATH = '/profile';
 
 export const TEMPLATE_REG = /^\s*\[\[\[([\s\S]+)\]\]\]\s*$/;
 export const CSS_CLEANER_REGEXP = /(\s*)([\w-]+\s*:\s*[^;]+;?|\})(\s*)/g;

--- a/src/custom-sidebar.ts
+++ b/src/custom-sidebar.ts
@@ -326,9 +326,8 @@ class CustomSidebar {
             const [index, configItem] = entry;
             if (configItem.element === activeAnchor) {
                 activeIndex = +index;
-            } else {
-                configItem.element.tabIndex = -1;
             }
+            configItem.element.tabIndex = -1;
         }
         if (forward) {
             focusIndex = activeIndex < lastIndex
@@ -403,6 +402,11 @@ class CustomSidebar {
                 ? this._getActivePaperIconElement(activeEl.shadowRoot)
                 : null;
         }
+        // In theory, activeElement could be null
+        // but this is hard to reproduce during the tests
+        // because there is always an element focused (e.g. the body)
+        // So excluding this from the coverage
+        /* istanbul ignore next */
         return null;
     }
 

--- a/src/custom-sidebar.ts
+++ b/src/custom-sidebar.ts
@@ -686,15 +686,16 @@ class CustomSidebar {
 
                     }
 
-                    // When the item is clicked
-                    orderItem.element.addEventListener(EVENT.MOUSEDOWN, this._itemTouchedBinded);
-                    orderItem.element.addEventListener(EVENT.KEYDOWN, (event: KeyboardEvent): void => {
-                        if (event.key === KEY.ENTER) {
-                            this._itemTouchedBinded();
-                        }
-                    });
-
                     if (!orderItem.hide) {
+
+                        // When the item is clicked
+                        orderItem.element.addEventListener(EVENT.MOUSEDOWN, this._itemTouchedBinded);
+                        orderItem.element.addEventListener(EVENT.KEYDOWN, (event: KeyboardEvent): void => {
+                            if (event.key === KEY.ENTER) {
+                                this._itemTouchedBinded();
+                            }
+                        });
+
                         this._items.push(orderItem);
                     }
 

--- a/tests/01 - basic-options.spec.ts
+++ b/tests/01 - basic-options.spec.ts
@@ -78,9 +78,7 @@ test('Sidebar new items', async ({ page }) => {
   await expect(automations).not.toHaveAttribute('target', '_blank');
 
   const hidden = page.locator(SELECTORS.SIDEBAR_ITEMS.HIDDEN);
-  await expect(hidden).toHaveText('Hidden', { useInnerText: true });
-  await expect(hidden).toHaveAttribute('href', '/hidden');
-  await expect(hidden).not.toHaveAttribute('target', '_blank');
+  await expect(hidden).not.toBeAttached();
 
 });
 
@@ -141,7 +139,6 @@ test('Sidebar order', async ({ page }) => {
     [SELECTORS.SIDEBAR_ITEMS.ENTITIES, '3'],
     [SELECTORS.SIDEBAR_ITEMS.AUTOMATIONS, '4'],
     [SELECTORS.SIDEBAR_ITEMS.TODO, '5'],
-    [SELECTORS.SIDEBAR_ITEMS.HIDDEN, '6'],
     [SELECTORS.SIDEBAR_ITEMS.ENERGY, '7'],
     [SELECTORS.SIDEBAR_ITEMS.MAP, '8'],
     [SELECTORS.SIDEBAR_ITEMS.HISTORY, '9'],
@@ -164,8 +161,7 @@ test('Sidebar no visible', async ({ page }) => {
   const items = [
     SELECTORS.SIDEBAR_ITEMS.ENERGY,
     SELECTORS.SIDEBAR_ITEMS.MAP,
-    SELECTORS.SIDEBAR_ITEMS.HISTORY,
-    SELECTORS.SIDEBAR_ITEMS.HIDDEN
+    SELECTORS.SIDEBAR_ITEMS.HISTORY
   ];
 
   for (const selector of items) {

--- a/tests/05 - interactions.spec.ts
+++ b/tests/05 - interactions.spec.ts
@@ -56,6 +56,29 @@ test('Clicking on items with the same root path should select the proper item', 
 
 });
 
+test('Hiting Enter with items focused should select the proper item', async ({ page }) => {
+
+  await visitHome(page);
+  await page.waitForTimeout(600);
+
+  await page.locator(SELECTORS.SIDEBAR_ITEMS.INTEGRATIONS).focus();
+  await page.waitForTimeout(600);
+
+  await page.keyboard.press('Enter');
+
+  await expect(page.locator(SELECTORS.SIDEBAR_ITEMS.INTEGRATIONS)).toHaveClass(SELECTED_CLASSNAME);
+  await expect(page.locator(SELECTORS.SIDEBAR_ITEMS.CONFIG)).not.toHaveClass(SELECTED_CLASSNAME);
+  
+  await page.locator(SELECTORS.SIDEBAR_ITEMS.ENTITIES).focus();
+  await page.waitForTimeout(600);
+
+  await page.keyboard.press('Enter');
+
+  await expect(page.locator(SELECTORS.SIDEBAR_ITEMS.ENTITIES)).toHaveClass(SELECTED_CLASSNAME);
+  await expect(page.locator(SELECTORS.SIDEBAR_ITEMS.CONFIG)).not.toHaveClass(SELECTED_CLASSNAME);
+
+});
+
 test('Visit a URL that matches with multiple items should select the proper item', async ({ page }) => {
 
   await page.goto('/config');
@@ -92,7 +115,7 @@ test('Visit a URL that matches with multiple items should select the proper item
 
 });
 
-test('Do not move the clicked item outside the viewport', async ({ page }) => {
+test('Restore the scroll after clicking on an element', async ({ page }) => {
 
   await page.setViewportSize({ width: 1024, height: 500 });
 
@@ -110,6 +133,33 @@ test('Do not move the clicked item outside the viewport', async ({ page }) => {
   const scrollTopStart = await page.locator(SELECTORS.PAPER_LIST_BOX).evaluate(element => element.scrollTop);
 
   await page.locator(SELECTORS.SIDEBAR_ITEMS.INTEGRATIONS).click({ delay: 150 });
+  await page.waitForTimeout(600);
+
+  expect(
+    await page.locator(SELECTORS.PAPER_LIST_BOX).evaluate(element => element.scrollTop)
+  ).toBe(scrollTopStart);
+
+});
+
+test('Restore the scroll after pressing Enter with an element focused', async ({ page }) => {
+
+  await page.setViewportSize({ width: 1024, height: 500 });
+
+  await page.goto('/');
+  await expect(page.locator(SELECTORS.HA_SIDEBAR)).toBeVisible();
+  await expect(page.locator(SELECTORS.HUI_VIEW)).toBeVisible();
+  await expect(page).toHaveScreenshot('02-sidebar-small-viewport.png', {
+    clip: {
+      ...SIDEBAR_CLIP,
+      height: 378
+    }
+  });
+  await page.waitForTimeout(600);
+
+  const scrollTopStart = await page.locator(SELECTORS.PAPER_LIST_BOX).evaluate(element => element.scrollTop);
+
+  await page.locator(SELECTORS.SIDEBAR_ITEMS.INTEGRATIONS).focus();
+  await page.keyboard.press('Enter');
   await page.waitForTimeout(600);
 
   expect(
@@ -168,5 +218,119 @@ test('If sidebar_editable is set to false it should not be possible to edit the 
   await page.goto('/profile');
 
   await expect(page.locator(SELECTORS.PROFILE_EDIT_BUTTON)).toHaveAttribute(ATTRIBUTES.DISABLED);
+
+});
+
+test('Navigate focused items with the up and down arrows', async ({ page }) => {
+
+  await visitHome(page);
+
+  await page.locator(SELECTORS.SIDEBAR_ITEMS.OVERVIEW).focus();
+
+  await page.keyboard.press('ArrowDown');
+
+  await expect(page.locator(SELECTORS.SIDEBAR_ITEMS.GOOGLE)).toBeFocused();
+
+  await page.keyboard.press('ArrowDown');
+
+  await expect(page.locator(SELECTORS.SIDEBAR_ITEMS.INTEGRATIONS)).toBeFocused();
+
+  await page.keyboard.press('ArrowUp');
+
+  await expect(page.locator(SELECTORS.SIDEBAR_ITEMS.GOOGLE)).toBeFocused();
+
+  await page.keyboard.press('ArrowUp');
+
+  await expect(page.locator(SELECTORS.SIDEBAR_ITEMS.OVERVIEW)).toBeFocused();
+
+  await page.keyboard.press('ArrowUp');
+
+  await expect(page.locator(SELECTORS.SIDEBAR_ITEMS.DEV_TOOLS)).toBeFocused();
+
+  await page.keyboard.press('ArrowUp');
+
+  await expect(page.locator(SELECTORS.SIDEBAR_ITEMS.CONFIG)).toBeFocused();
+
+  await page.keyboard.press('ArrowDown');
+
+  await expect(page.locator(SELECTORS.SIDEBAR_ITEMS.DEV_TOOLS)).toBeFocused();
+
+  await page.keyboard.press('ArrowDown');
+
+  await expect(page.locator(SELECTORS.SIDEBAR_ITEMS.OVERVIEW)).toBeFocused();
+
+});
+
+test('Navigate focused items with tabs', async ({ page }) => {
+
+  await visitHome(page);
+
+  await page.locator(SELECTORS.SIDEBAR_ITEMS.OVERVIEW).focus();
+
+  await page.keyboard.press('Tab');
+
+  await expect(page.locator(SELECTORS.SIDEBAR_PAPER_ICON_ITEMS.GOOGLE)).toBeFocused();
+
+  await page.keyboard.press('Tab');
+
+  await expect(page.locator(SELECTORS.SIDEBAR_PAPER_ICON_ITEMS.INTEGRATIONS)).toBeFocused();
+
+  await page.keyboard.down('Shift');
+  await page.keyboard.press('Tab');
+
+  await expect(page.locator(SELECTORS.SIDEBAR_PAPER_ICON_ITEMS.GOOGLE)).toBeFocused();
+
+  await page.keyboard.press('Tab');
+
+  await page.locator(SELECTORS.SIDEBAR_PAPER_ICON_ITEMS.OVERVIEW).focus();
+
+  await page.keyboard.press('Tab');
+
+  await expect(page.locator(SELECTORS.SIDEBAR_HA_ICON_BUTTON)).toBeFocused();
+
+  await page.keyboard.up('Shift');
+  await page.keyboard.press('Tab');
+
+  await expect(page.locator(SELECTORS.SIDEBAR_ITEMS.OVERVIEW)).toBeFocused();
+
+  await page.locator(SELECTORS.SIDEBAR_ITEMS.CONFIG).focus();
+
+  await page.keyboard.press('Tab');
+
+  await expect(page.locator(SELECTORS.SIDEBAR_PAPER_ICON_ITEMS.DEV_TOOLS)).toBeFocused();
+
+  await page.keyboard.press('Tab');
+
+  await expect(page.locator(SELECTORS.NOTIFICATIONS)).toBeFocused();
+
+  await page.keyboard.press('Tab');
+
+  await expect(page.locator(SELECTORS.PROFILE)).toBeFocused();
+
+  await page.keyboard.down('Shift');
+  await page.keyboard.press('Tab');
+
+  await expect(page.locator(SELECTORS.NOTIFICATIONS)).toBeFocused();
+
+  await page.keyboard.press('Tab');
+
+  await expect(page.locator(SELECTORS.SIDEBAR_PAPER_ICON_ITEMS.DEV_TOOLS)).toBeFocused();
+
+});
+
+test('Pressing tab without being in the sidebar will not select any item', async ({ page }) => {
+
+  await visitHome(page);
+
+  await page.evaluate(() => {
+    const selected = document.activeElement;
+    if (selected && selected instanceof HTMLElement) {
+      selected.blur();
+    }
+  });
+
+  await page.keyboard.press('Tab');
+
+  await expect(page.locator(SELECTORS.SIDEBAR_ITEMS.OVERVIEW)).not.toBeFocused();
 
 });

--- a/tests/constants.ts
+++ b/tests/constants.ts
@@ -6,29 +6,54 @@ const getSidebarItemSelector = (panel: string): string => {
     return  `paper-listbox > a[data-panel="${panel}"]`;
 }
 
+const getPaperIconSelector = (panel: string): string => {
+    const anchorSelector = getSidebarItemSelector(panel);
+    return `${anchorSelector} > paper-icon-item`;
+};
+
+export const PANELS = {
+    OVERVIEW: 'lovelace',
+    ENERGY: 'energy',
+    MAP: 'map',
+    LOGBOOK: 'logbook',
+    HISTORY: 'history',
+    MEDIA_BROWSER: 'media-browser',
+    TODO: 'todo',
+    DEV_TOOLS: 'developer-tools',
+    CONFIG: 'config',
+    GOOGLE: 'google',
+    INTEGRATIONS: 'integrations',
+    ENTITIES: 'entities',
+    AUTOMATIONS: 'automations',
+    HIDDEN: 'hidden'
+}
+
+const SIDEBAR_ITEMS = Object.fromEntries(
+    Object.entries(PANELS).map(([key, value]) => [
+        key,
+        getSidebarItemSelector(value)
+    ])
+);
+
+const SIDEBAR_PAPER_ICON_ITEMS = Object.fromEntries(
+    Object.entries(PANELS).map(([key, value]) => [
+        key,
+        getPaperIconSelector(value)
+    ])
+);
+
 export const SELECTORS = {
     TITLE: '.menu .title',
+    SIDEBAR_HA_ICON_BUTTON: '.menu ha-icon-button',
     SIDEBAR_EDIT_BUTTON: '.menu mwc-button',
     PROFILE_EDIT_BUTTON: '.content > ha-card ha-settings-row > mwc-button',
+    NOTIFICATIONS: '.notifications-container .notifications',
+    PROFILE: '.profile paper-icon-item',
     HA_SIDEBAR: 'ha-sidebar',
     HUI_VIEW: 'hui-view',
     PAPER_LIST_BOX: 'paper-listbox',
-    SIDEBAR_ITEMS: {
-        OVERVIEW: getSidebarItemSelector('lovelace'),
-        ENERGY: getSidebarItemSelector('energy'),
-        MAP: getSidebarItemSelector('map'),
-        LOGBOOK: getSidebarItemSelector('logbook'),
-        HISTORY: getSidebarItemSelector('history'),
-        MEDIA_BROWSER: getSidebarItemSelector('media-browser'),
-        TODO: getSidebarItemSelector('todo'),
-        DEV_TOOLS: getSidebarItemSelector('developer-tools'),
-        CONFIG: getSidebarItemSelector('config'),
-        GOOGLE: getSidebarItemSelector('google'),
-        INTEGRATIONS: getSidebarItemSelector('integrations'),
-        ENTITIES: getSidebarItemSelector('entities'),
-        AUTOMATIONS: getSidebarItemSelector('automations'),
-        HIDDEN: getSidebarItemSelector('hidden')
-    }
+    SIDEBAR_ITEMS,
+    SIDEBAR_PAPER_ICON_ITEMS
 };
 
 export const ATTRIBUTES = {


### PR DESCRIPTION
This pull request implements a focus trap functionality to make a custom keyboard navigation using the arrow keys or through tabs to follow the CSS order instead of the DOM order. 

Previously, trying to navigate through the sidebar items using the keyboard led to an unordered navigation due to the fact that it followed the DOM order not the CSS order of the elements.

| Before | After |
| ------ | ----- |
| ![keyboard-navigation-buggy](https://github.com/elchininet/custom-sidebar/assets/3728220/46fa05f2-496c-4130-88e6-68ace976df6f) | ![keyboard-navigation-fixed](https://github.com/elchininet/custom-sidebar/assets/3728220/12babca8-0508-4fe7-9b3d-2a0bbbbc3f5e) |