### PR TITLE
Implement tooltip for new items

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -48,6 +48,8 @@ export enum ATTRIBUTE {
 
 export enum EVENT {
     MOUSEDOWN = 'mousedown',
+    MOUSEENTER = 'mouseenter',
+    MOUSELEAVE = 'mouseleave',
     KEYDOWN = 'keydown',
     HASS_EDIT_SIDEBAR = 'hass-edit-sidebar'
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -17,8 +17,11 @@ export interface PartialPanelResolver extends HTMLElement {
     }
 }
 
-export interface PaperListBox extends HTMLElement {
-    _updateAttrForSelected: () => void;
+export interface Sidebar extends HTMLElement {
+    alwaysExpand: boolean;
+    _mouseLeaveTimeout?: number;
+    _showTooltip: (anchor: HTMLAnchorElement) => void;
+    _hideTooltip: () => void;
 }
 
 export enum Match {

--- a/tests/05 - interactions.spec.ts
+++ b/tests/05 - interactions.spec.ts
@@ -334,3 +334,25 @@ test('Pressing tab without being in the sidebar will not select any item', async
   await expect(page.locator(SELECTORS.SIDEBAR_ITEMS.OVERVIEW)).not.toBeFocused();
 
 });
+
+test('Tooltip behaviour in new items', async ({ page }) => {
+
+  await visitHome(page);
+
+  await page.locator(SELECTORS.SIDEBAR_PAPER_ICON_ITEMS.GOOGLE).hover();
+
+  await expect(page.locator(SELECTORS.TOOLTIP)).not.toBeVisible();
+
+  await page.locator(SELECTORS.SIDEBAR_HA_ICON_BUTTON).click();
+
+  await expect(page.locator(SELECTORS.HA_SIDEBAR)).not.toHaveAttribute('expanded');
+
+  await page.locator(SELECTORS.SIDEBAR_PAPER_ICON_ITEMS.GOOGLE).hover();
+
+  await expect(page.locator(SELECTORS.TOOLTIP)).toBeVisible();
+
+  await expect(page.locator(SELECTORS.TOOLTIP)).toContainText('Google');
+
+  await page.locator(SELECTORS.SIDEBAR_HA_ICON_BUTTON).click();
+
+});

--- a/tests/constants.ts
+++ b/tests/constants.ts
@@ -52,6 +52,7 @@ export const SELECTORS = {
     HA_SIDEBAR: 'ha-sidebar',
     HUI_VIEW: 'hui-view',
     PAPER_LIST_BOX: 'paper-listbox',
+    TOOLTIP: '.tooltip',
     SIDEBAR_ITEMS,
     SIDEBAR_PAPER_ICON_ITEMS
 };


### PR DESCRIPTION
When the sidebar is collapsed, sidebar items show a tooltip on hover. New items were not having this behaviour. This pull request mimics the behaviour of the regular items on new items making the tooltip appear when hovering them.

<img width="214" alt="image" src="https://github.com/elchininet/custom-sidebar/assets/3728220/7f9f43bb-c9e0-449f-a61a-814fc7333ec1">
