### PR TITLE
Fix a typo in YAML examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ The next example will set the title of the sidebar as "My Home" followed by the 
 title: '[[[ "My Home " + new Date(states("sensor.date_time_iso")).toLocaleTimeString().slice(0, 5) ]]]'
 order:
   - item: hacs
-    notification: '[[[ state_attr("sensor.hacs", "repositories").length || '' ]]]'
+    notification: '[[[ state_attr("sensor.hacs", "repositories").length || "" ]]]'
   - new_item: true
     item: info
     name: '[[[ "Info (" + state_attr("update.home_assistant_supervisor_update", "latest_version") + ")" ]]]'

--- a/sidebar-config.yaml
+++ b/sidebar-config.yaml
@@ -26,7 +26,7 @@ order:
     order: 5
   - item: hacs
     order: 6
-    notification: '[[[ state_attr("sensor.hacs", "repositories").length || '' ]]]'
+    notification: '[[[ state_attr("sensor.hacs", "repositories").length || "" ]]]'
   - item: config
     bottom: true
     order: 7


### PR DESCRIPTION
This pull request fixes a typo in the documentation and in the `sidebar-config.yaml` example file.

This:

```yaml
notification: '[[[ state_attr("sensor.hacs", "repositories").length || '' ]]]'
```

Is incorrect, the quotes after the Logical OR should be double:

```yaml
notification: '[[[ state_attr("sensor.hacs", "repositories").length || "" ]]]'
```

If this code is used in the previous way, [it will bring issues](https://github.com/elchininet/custom-sidebar/issues/73).