### PR TITLE
Remove Coveralls from the Nightly beta tests and build workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,10 +34,6 @@ jobs:
           pnpm test:all
       - name: Create coverage
         run: pnpm coverage:report
-      - name: Coveralls
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build Changelog
         id: build_changelog
         uses: mikepenz/release-changelog-builder-action@v3

--- a/.github/workflows/ha-beta-tests.yaml
+++ b/.github/workflows/ha-beta-tests.yaml
@@ -30,10 +30,6 @@ jobs:
           TAG=beta pnpm test:ci
       - name: Create coverage
         run: pnpm coverage:report
-      - name: Coveralls
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/upload-artifact@v3
         if: always()
         with:


### PR DESCRIPTION
This pull request removes the Coveralls job from the Nightly beta tests and build workflows.