### PR TITLE
Retry the Home Assistant api calls with a delay

### DIFF
--- a/tests/constants.ts
+++ b/tests/constants.ts
@@ -1,5 +1,6 @@
 export const BASE_URL = 'http://host.docker.internal:8123';
 export const MAXIMUM_RETRIES = 10;
+export const RETRY_DELAY = 200;
 export const JSON_PATH = 'local/sidebar-config.json*';
 
 export const PANELS = {

--- a/tests/utilities.ts
+++ b/tests/utilities.ts
@@ -2,7 +2,8 @@ import { Page } from '@playwright/test';
 import {
     BASE_URL,
     JSON_PATH,
-    MAXIMUM_RETRIES
+    MAXIMUM_RETRIES,
+    RETRY_DELAY
 } from './constants';
 
 export const haConfigRequest = async (file: string, retries = 0) => {
@@ -22,7 +23,13 @@ export const haConfigRequest = async (file: string, retries = 0) => {
         if (response.ok || retries >= MAXIMUM_RETRIES) {
             return response;
         }
-        return haConfigRequest(file, retries + 1);
+        return new Promise((resolve) => {
+            setTimeout(() => {
+                resolve(
+                    haConfigRequest(file, retries + 1)
+                );
+            }, RETRY_DELAY);
+        });
     });
 };
 


### PR DESCRIPTION
During the tests, when calling the Home Assistant API, it returns an error. The utility retry the calls multiple times but without any delay, and this provokes that multiple times it fails. This pull request introduces a delay in these calls to avoid this issue.