### PR TITLE
Remove Docker Cache action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,10 +21,6 @@ jobs:
         with:
           node-version: '18'
           cache: 'pnpm'
-      - name: Cache Docker images
-        uses: ScribeMD/docker-cache@0.3.7
-        with:
-          key: docker-v1-${{ runner.os }}-${{ hashFiles('.hass/config/.HA_VERSION', '.playwright_docker_version') }}
       - name: Install deps
         run: pnpm install
       - name: E2E tests

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,10 +22,6 @@ jobs:
         with:
           node-version: '18'
           cache: 'pnpm'
-      - name: Cache Docker images
-        uses: ScribeMD/docker-cache@0.3.7
-        with:
-          key: docker-v1-${{ runner.os }}-${{ hashFiles('.hass/config/.HA_VERSION', '.playwright_docker_version') }}
       - name: Install
         run: pnpm install
       - name: E2E tests


### PR DESCRIPTION
When the Docker images were loaded from cache, tests started to fail. This pull request removes temporarily the Docker Cache action from the workflows until a solution is provided for this.