### PR TITLE
Remove compatibility with Home Assistant equal or lower to 2024.3.x

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,15 +1,7 @@
 import { HomeAssistant, Hass } from 'home-assistant-javascript-templates';
 
-export type Version = [number, number, string];
-
-export interface HassObject extends Hass {
-    config: {
-        version: string;
-    };
-}
-
 export interface HomeAsssistantExtended extends HomeAssistant {
-    hass: HassObject;
+    hass: Hass;
 }
 
 export interface PartialPanelResolver extends HTMLElement {

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -1,8 +1,4 @@
-import {
-    ConfigOrder,
-    ConfigException,
-    Version
-} from '@types';
+import { ConfigOrder, ConfigException } from '@types';
 import {
     NAMESPACE,
     MAX_ATTEMPTS,
@@ -142,19 +138,4 @@ export const addStyle = (css: string, elem: ShadowRoot): void => {
     style.setAttribute('id', `${NAMESPACE}_${name}`);
     elem.appendChild(style);
     style.innerHTML = css.replace(CSS_CLEANER_REGEXP, '$2');
-};
-
-export const parseVersion = (version: string | undefined): Version | null => {
-    const versionRegExp = /^(\d+)\.(\d+)\.(\w+)(?:\.(\w+))?$/;
-    const match = version
-        ? version.match(versionRegExp)
-        : null;
-    if (match) {
-        return [
-            +match[1],
-            +match[2],
-            match[3]
-        ];
-    }
-    return null;
 };


### PR DESCRIPTION
This pull request removes the compatibility with Home Assistant versions equal or lower to `2024.3.x`. For some months this compatibility has been maintained to avoid issues for users that don't update Home Assistant inmediately at its releases, but it has been a while since this, so it is time to remove this compatibility and the extra code that it requires. 