### PR TITLE
Fix fetch config error messages

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,5 +1,7 @@
 export const NAMESPACE = 'custom-sidebar';
-export const CONFIG_PATH = '/local/sidebar-config';
+export const LOCAL_PATH = '/local/';
+export const CONFIG_NAME = 'sidebar-config';
+export const CONFIG_PATH = `${LOCAL_PATH}${CONFIG_NAME}`;
 export const MAX_ATTEMPTS = 100;
 export const RETRY_DELAY = 50;
 

--- a/src/fetchers/json.ts
+++ b/src/fetchers/json.ts
@@ -1,11 +1,15 @@
 import { Config } from '@types';
-import { NAMESPACE, CONFIG_PATH } from '@constants';
+import {
+    NAMESPACE,
+    CONFIG_NAME,
+    CONFIG_PATH
+} from '@constants';
 import { randomId } from '@utilities';
 import { validateConfig } from '@validators';
 
 export const fetchConfig = async (): Promise<Config> => {
     const errorNotFound = `${NAMESPACE}: JSON config file not found.`;
-    const errorSuffix = 'Make sure you have valid config in /config/www/sidebar-order.json file.';
+    const errorSuffix = `Make sure you have valid config in /config/www/${CONFIG_NAME}.json file.`;
     return new Promise<Config>((resolve) => {
         fetch(`${CONFIG_PATH}.json?hash=${randomId()}`)
             .then((response: Response) => {

--- a/src/fetchers/yaml.ts
+++ b/src/fetchers/yaml.ts
@@ -1,12 +1,16 @@
 import jsYaml from 'js-yaml';
 import { Config } from '@types';
-import { NAMESPACE, CONFIG_PATH } from '@constants';
+import {
+    NAMESPACE,
+    CONFIG_NAME,
+    CONFIG_PATH
+} from '@constants';
 import { randomId } from '@utilities';
 import { validateConfig } from '@validators';
 
 export const fetchConfig = async (): Promise<Config> => {
     const errorNotFound = `${NAMESPACE}: YAML config file not found.`;
-    const errorSuffix = 'Make sure you have valid config in /config/www/sidebar-order.yaml file.';
+    const errorSuffix = `Make sure you have valid config in /config/www/${CONFIG_NAME}.yaml file.`;
     return new Promise<Config>((resolve) => {
         fetch(`${CONFIG_PATH}.yaml?hash=${randomId()}`)
             .then((response: Response) => {

--- a/tests/08 - fetch-config-errors.spec.ts
+++ b/tests/08 - fetch-config-errors.spec.ts
@@ -23,7 +23,7 @@ test('JSON not found', async ({ page }) => {
     await expect(page.locator(SELECTORS.HA_SIDEBAR)).toBeVisible();
     expect(errors).toEqual(
         expect.arrayContaining([
-            `${ERROR_PREFIX} JSON config file not found.\nMake sure you have valid config in /config/www/sidebar-order.json file.`
+            `${ERROR_PREFIX} JSON config file not found.\nMake sure you have valid config in /config/www/sidebar-config.json file.`
         ])
     );
 
@@ -49,7 +49,7 @@ test('JSON server error', async ({ page }) => {
     await expect(page.locator(SELECTORS.HA_SIDEBAR)).toBeVisible();
     expect(errors).toEqual(
         expect.arrayContaining([
-            `${ERROR_PREFIX} JSON config file not found.\nMake sure you have valid config in /config/www/sidebar-order.json file.`
+            `${ERROR_PREFIX} JSON config file not found.\nMake sure you have valid config in /config/www/sidebar-config.json file.`
         ])
     );
 
@@ -96,7 +96,7 @@ test('JSON id warning', async ({ page }) => {
     await expect(page.locator(SELECTORS.HA_SIDEBAR)).toBeVisible();
     expect(warnings).toEqual(
         expect.arrayContaining([
-            `${ERROR_PREFIX} You seem to be using the example configuration.\nMake sure you have valid config in /config/www/sidebar-order.json file.`
+            `${ERROR_PREFIX} You seem to be using the example configuration.\nMake sure you have valid config in /config/www/sidebar-config.json file.`
         ])
     );
 


### PR DESCRIPTION
When the plugin fails to load the configuration the error messages are showing an old configuration name instead the new one, something that is confusing for an user that needs to fix the config path. This pull request fixes that issue.