### PR TITLE
Change Media Browser item name in the config examples

### DIFF
--- a/sidebar-config.json
+++ b/sidebar-config.json
@@ -96,7 +96,7 @@
       "hide": true
     },
     {
-      "item": "media browser",
+      "item": "media",
       "hide": true
     }
   ],

--- a/sidebar-config.yaml
+++ b/sidebar-config.yaml
@@ -60,7 +60,7 @@ order:
     hide: true
   - item: energy
     hide: true
-  - item: media browser
+  - item: media
     hide: true
 exceptions:
   - user:


### PR DESCRIPTION
The `Media Browser` item in the sidebar has changed its name to `Media` in the latest versions of Home Assistant. The path keeps neing `media-browser` but the text not, this provoked that the example configs in the repo failed to hide it. This pull request fixes this.