### PR TITLE
Update the package home-assistant-javascript-templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,12 +296,10 @@ order:
   - item: hacs
     notification: |
       [[[
-        const updates = Object.values(states.update);
-        const hacsUpdates = updates.filter((update) => {
-          const { entity_id, state } = update;
-          return hass.entities[entity_id].platform === 'hacs' && state === 'on';
-        });
-        return hacsUpdates.length || '';
+        const outdatedHacsEntities = Object.values(entities.update).filter(
+          (entity) => entity.platform === 'hacs' && is_state(entity.entity_id, 'on')
+        );
+        return outdatedHacsEntities.length || '';
       ]]]
   - new_item: true
     item: info
@@ -318,7 +316,7 @@ order:
   "order": [
     {
       "item": "hacs",
-      "notification": "[[[ return Object.values(states.update).filter((update) => hass.entities[update.entity_id].platform === 'hacs' && update.state === 'on').length || '' ]]]"
+      "notification": "[[[ return Object.values(entities.update).filter((entity) => entity.platform === 'hacs' && is_state(entity.entity_id, 'on')).length || '' ]]]"
     },
     {
       "new_item": true,

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "typescript-eslint": "^8.2.0"
   },
   "dependencies": {
-    "home-assistant-javascript-templates": "^3.1.1",
+    "home-assistant-javascript-templates": "^4.0.0",
     "home-assistant-query-selector": "^4.2.0",
     "js-yaml": "^4.1.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       home-assistant-javascript-templates:
-        specifier: ^3.1.1
-        version: 3.1.1
+        specifier: ^4.0.0
+        version: 4.0.0
       home-assistant-query-selector:
         specifier: ^4.2.0
         version: 4.2.0
@@ -987,8 +987,8 @@ packages:
     resolution: {integrity: sha512-J00e55zffgi3yVnUp0UdbMztNkr2PnizEkOe9URNohnrNhW5X0QpegkuLpOmFQInpi93Nb8MCjQRHAiCDF42NQ==}
     engines: {node: '>=10.0.0'}
 
-  home-assistant-javascript-templates@3.1.1:
-    resolution: {integrity: sha512-6ytok3f1djd8nYGTx3XWFK7zqZ/Si/RWPB2gDe/NWdKWz3+JtDG3ZZ8EcEBgcgIDRKecPXp2gdf9fC053IJFKA==}
+  home-assistant-javascript-templates@4.0.0:
+    resolution: {integrity: sha512-Ng63AO56T0scmYWe/j+i+UILVKEhdJGUI6gBGr+GfACuXPkmM9GUIPzCGXhoRSa85u3Od+EuMMUlkE+Bk+8QCA==}
 
   home-assistant-query-selector@4.2.0:
     resolution: {integrity: sha512-8VwrqTunsE3sgakCirBdQgrZTvWgT1SIaVthpgVCeaA/8dUK0qQfn3JFUcwaa8xm0NUa8yDgjRkxKe9lGHA65Q==}
@@ -2583,7 +2583,7 @@ snapshots:
 
   helpertypes@0.0.19: {}
 
-  home-assistant-javascript-templates@3.1.1: {}
+  home-assistant-javascript-templates@4.0.0: {}
 
   home-assistant-query-selector@4.2.0:
     dependencies:

--- a/sidebar-config.json
+++ b/sidebar-config.json
@@ -40,7 +40,7 @@
     {
       "item": "hacs",
       "order": 6,
-      "notification": "[[[ state_attr('sensor.hacs', 'repositories').length || '' ]]]"
+      "notification": "[[[ return Object.values(entities.update).filter((entity) => entity.platform === 'hacs' && is_state(entity.entity_id, 'on')).length || '' ]]]"
     },
     {
       "item": "config",

--- a/sidebar-config.yaml
+++ b/sidebar-config.yaml
@@ -26,7 +26,13 @@ order:
     order: 5
   - item: hacs
     order: 6
-    notification: '[[[ state_attr("sensor.hacs", "repositories").length || "" ]]]'
+    notification: |
+      [[[
+        const outdatedHacsEntities = Object.values(entities.update).filter(
+          (entity) => entity.platform === 'hacs' && is_state(entity.entity_id, 'on')
+        );
+        return outdatedHacsEntities.length || '';
+      ]]]
   - item: config
     bottom: true
     order: 7


### PR DESCRIPTION
This pull request updates the package `home-assistant-javascript-templates` giving the possibility of using new objects and methods in the `JavaScript` templates.

Also, the examples of the `JavaScript` templates to set a notification with the number of `HACS` updates have been updates using some of the new methods and objects.