### PR TITLE
Fix non existent data-panel property

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@rollup/plugin-replace": "^5.0.7",
     "@rollup/plugin-terser": "^0.4.4",
     "@types/js-yaml": "^4.0.9",
-    "@types/node": "^22.5.2",
+    "@types/node": "22.5.2",
     "dotenv-cli": "^7.4.2",
     "eslint": "^9.9.1",
     "globals": "^15.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,7 +40,7 @@ importers:
         specifier: ^4.0.9
         version: 4.0.9
       '@types/node':
-        specifier: ^22.5.2
+        specifier: 22.5.2
         version: 22.5.2
       dotenv-cli:
         specifier: ^7.4.2

--- a/src/custom-sidebar.ts
+++ b/src/custom-sidebar.ts
@@ -603,7 +603,7 @@ class CustomSidebar {
 
                                 const matchText = (
                                     (!!exact && item === text) ||
-                                    (!exact && text.toLowerCase().includes(itemLowerCase))
+                                    (!exact && !!text?.toLowerCase().includes(itemLowerCase))
                                 );
 
                                 if (matchText) {


### PR DESCRIPTION
This pull request fixes an issue that was ocurring in an edge case scenario:

* Non admin-user
* Using the Home Assistant Companion App
* Using a `data-panel` matcher to try to match the item `App Configuration`

What happens is that this element doesn't have a `data-panel` attribute:

![image](https://github.com/user-attachments/assets/8eac5ab0-7259-4c14-9303-172ead09814a)

This will provoke an error if we try to call `toLowerCase` in the text retrieved from the `data-panel` attribute because as the attribute doesn't exist it will be `null`.

In this pull request [the optional chaining operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) has been used to avoid trhowing an error if the property is `null`.