### PR TITLE
Manage the blocking of the sidebar title events with the sidebar CSSs

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -9,6 +9,8 @@ export const BOOLEAN_TYPE = 'boolean';
 export const STRING_TYPE = 'string';
 export const UNDEFINED_TYPE = 'undefined';
 
+export const BLOCKED_PROPERTY = 'data-blocked';
+
 export enum ELEMENT {
     SIDEBAR = 'ha-sidebar',
     PAPER_LISTBOX = 'paper-listbox',


### PR DESCRIPTION
This pull request changes how to apply the CSS styles to the sidebar header when the `sidebar_editable` property is set as `false`. Instead of accesing the elements and change their CSS through their `style` property, fixed CSS rules are added to the sidebar custom CSSs, and these CSS rules are activated when a `data-parameter` is present in the menu element. On top of that, instead of querying the shadowRoot of the sidebar, the menu element is retrieved in an async way using query feature of `home-assistant-query-selector`.