### PR TITLE
Improve configuration examples

### DIFF
--- a/sidebar-config.json
+++ b/sidebar-config.json
@@ -106,8 +106,29 @@
         "Jim Hawkins",
         "Long John Silver"
       ],
-      "base_order": false,
-      "order": []
+      "extend_from_base": false,
+      "order": [
+        {
+          "new_item": true,
+          "item": "Updates",
+          "href": "/config/updates",
+          "icon": "mdi:update"
+        }
+      ]
+    },
+    {
+      "user": "Palaus",
+      "extend_from_base": true,
+      "order": [
+        {
+          "item": "history",
+          "order": 12
+        },
+        {
+          "item": "media",
+          "order": 13
+        }
+      ]
     }
   ],
   "id": "example_json (remove this from your config or replace with any other string)"

--- a/sidebar-config.yaml
+++ b/sidebar-config.yaml
@@ -72,6 +72,17 @@ exceptions:
   - user:
     - Jim Hawkins
     - Long John Silver
-    base_order: false
-    order: []
+    extend_from_base: false
+    order:
+      - new_item: true
+        item: Updates
+        href: "/config/updates"
+        icon: mdi:update
+  - user: Palaus
+    extend_from_base: true
+    order:
+      - item: history
+        order: 12
+      - item: media
+        order: 13
 id: example_yaml (remove this from your config or replace with any other string)


### PR DESCRIPTION
This merge request improves the configuration examples to avoid confussion about the usage of the exceptions. Some items have been added to the exceptions to show what is the shape of the items inside the `order` property. Also, the `base_order` property in the exceptions has been renamed to `extend_from_base` wich is the new property to extend from the base configuration.