### PR TITLE
Add new configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Add a file named `sidebar-config.yaml` or `sidebar-config.json` into your `<conf
 | info_color<sup>\*</sup> | String                        | no       | Sets the color of the info texts of the sidebar items |
 | info_color_selected<sup>\*</sup> | String               | no       | Sets the color of the info text of the selected sidebar item |
 | notification_color<sup>\*</sup>  | String               | no       | Sets the color of the sidebar notifications |
+| divider_color<sup>\*</sup>       | String               | no       | Sets the color of the sidebar dividers |
 | styles             | String                             | no       | Custom styles that will be added to the styles block of the plugin. Useful to override styles |
 
 >\* These options allow [JavaScript](#javascript-templates) or [Jinja](#jinja-templates) templates.

--- a/README.md
+++ b/README.md
@@ -146,7 +146,8 @@ Add a file named `sidebar-config.yaml` or `sidebar-config.json` into your `<conf
 | icon_color_selected<sup>\*</sup> | String               | no       | Sets the icon color of the selected sidebar item |
 | text_color<sup>\*</sup> | String                        | no       | Sets the text color of the sidebar items |
 | text_color_selected<sup>\*</sup> | String               | no       | Sets the text color of the selected sidebar item |
-| selection_color<sup>\*</sup> | String                   | no       | Sets the color of the selected item background. If it is not specified, the `icon_color_selected` will be used (this color has an opacity of 0.12) |
+| selection_color<sup>\*</sup> | String                   | no       | Sets the color of the selected item background. If it is not specified, the `icon_color_selected` will be used |
+| selection_opacity<sup>\*</sup> | Number or String       | no       | Sets the opacity of the selected item background. If it is not specified, the default 0.12 will be used |
 | info_color<sup>\*</sup> | String                        | no       | Sets the color of the info texts of the sidebar items |
 | info_color_selected<sup>\*</sup> | String               | no       | Sets the color of the info text of the selected sidebar item |
 | notification_color<sup>\*</sup>  | String               | no       | Sets the color of the sidebar notifications |
@@ -168,7 +169,8 @@ Add a file named `sidebar-config.yaml` or `sidebar-config.json` into your `<conf
 | icon_color_selected<sup>\*</sup> | String | no  | Sets the icon color of the item when it is selected (it overrides the global `icon_color_selected`) |
 | text_color<sup>\*</sup> | String    | no        | Sets the text color of the item (it overrides the global `text_color`) |
 | text_color_selected<sup>\*</sup> | String | no  | Sets the text color of the item when it is selected (it overrides the global `text_color_selected`) |
-| selection_color<sup>\*</sup> | String     | no  | Sets the color of the item background when it is selected. If it is not specified, the `icon_color_selected` will be used (this color has an opacity of 0.12 and it overrides the global `selection_color`) |
+| selection_color<sup>\*</sup> | String     | no  | Sets the color of the item background when it is selected. If it is not specified, the `icon_color_selected` will be used (it overrides the global `selection_color`) |
+| selection_opacity<sup>\*</sup> | Number or String | no       | Sets the opacity of the item background when it is selected. If it is not specified, the default 0.12 will be used (it overrides the global `selection_opacity`) |
 | info_color<sup>\*</sup> | String | no           | Sets the color of the info text (it overrides the global `info_color`) |
 | info_color_selected<sup>\*</sup> | String | no  | Sets the color of the info text when the item is selected (it overrides the global `info_color_selected`) |
 | notification_color<sup>\*</sup>  | String | no  | Sets the notification color (it overrides the global `notification_color`) |

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -39,6 +39,7 @@ export enum SELECTOR {
     SIDEBAR_NOTIFICATIONS = '.notifications',
     PROFILE = '.profile',
     MENU = '.menu',
+    DIVIDER = '.divider',
     HA_ICON_BUTTON = 'ha-icon-button'
 }
 
@@ -52,6 +53,7 @@ export enum CSS_VARIABLES {
     SIDEBAR_BUTTON_COLOR = '--sidebar-icon-color',
     SIDEBAR_MENU_BUTTON_BACKGROUND_COLOR = '--sidebar-menu-button-background-color',
     PRIMARY_BACKGROUND_COLOR = '--primary-background-color',
+    DIVIDER_COLOR = '--divider-color',
     CUSTOM_SIDEBAR_BACKGROUND = '--custom-sidebar-background',
     CUSTOM_SIDEBAR_MENU_BACKGROUND = '--custom-sidebar-menu-background',
     CUSTOM_SIDEBAR_TEXT_COLOR = '--custom-sidebar-text-color',
@@ -62,7 +64,8 @@ export enum CSS_VARIABLES {
     CUSTOM_SIDEBAR_INFO_COLOR = '--custom-sidebar-info-color',
     CUSTOM_SIDEBAR_SELECTED_INFO_COLOR = '--custom-sidebar-selected-info-color',
     CUSTOM_SIDEBAR_NOTIFICATION_COLOR = '--custom-sidebar-notification-color',
-    CUSTOM_SIDEBAR_SELECTION_OPACITY = '--custom-sidebar-selection-opacity'
+    CUSTOM_SIDEBAR_SELECTION_OPACITY = '--custom-sidebar-selection-opacity',
+    CUSTOM_SIDEBAR_DIVIDER_COLOR = '--custom-sidebar-divider-color'
 }
 
 export enum CLASS {

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -11,6 +11,7 @@ export const FLUSH_PROMISE_DELAY = 1;
 export const BOOLEAN_TYPE = 'boolean';
 export const STRING_TYPE = 'string';
 export const UNDEFINED_TYPE = 'undefined';
+export const NUMBER_TYPE = 'number';
 
 export const BLOCKED_PROPERTY = 'data-blocked';
 
@@ -61,6 +62,7 @@ export enum CSS_VARIABLES {
     CUSTOM_SIDEBAR_INFO_COLOR = '--custom-sidebar-info-color',
     CUSTOM_SIDEBAR_SELECTED_INFO_COLOR = '--custom-sidebar-selected-info-color',
     CUSTOM_SIDEBAR_NOTIFICATION_COLOR = '--custom-sidebar-notification-color',
+    CUSTOM_SIDEBAR_SELECTION_OPACITY = '--custom-sidebar-selection-opacity'
 }
 
 export enum CLASS {

--- a/src/custom-sidebar.ts
+++ b/src/custom-sidebar.ts
@@ -574,7 +574,8 @@ class CustomSidebar {
                     ['info_color',            CSS_VARIABLES.CUSTOM_SIDEBAR_INFO_COLOR],
                     ['info_color_selected',   CSS_VARIABLES.CUSTOM_SIDEBAR_SELECTED_INFO_COLOR],
                     ['notification_color',    CSS_VARIABLES.CUSTOM_SIDEBAR_NOTIFICATION_COLOR],
-                    ['selection_opacity',     CSS_VARIABLES.CUSTOM_SIDEBAR_SELECTION_OPACITY]
+                    ['selection_opacity',     CSS_VARIABLES.CUSTOM_SIDEBAR_SELECTION_OPACITY],
+                    ['divider_color',         CSS_VARIABLES.CUSTOM_SIDEBAR_DIVIDER_COLOR]
                 ]
             );
 
@@ -627,6 +628,7 @@ class CustomSidebar {
                     background: var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_BACKGROUND }, var(${ CSS_VARIABLES.SIDEBAR_BACKGROUND_COLOR })) !important;
                     & ${ SELECTOR.MENU } {
                         background: var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_MENU_BACKGROUND }, var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_BACKGROUND }, var(${ CSS_VARIABLES.SIDEBAR_MENU_BUTTON_BACKGROUND_COLOR }, var(${ CSS_VARIABLES.PRIMARY_BACKGROUND_COLOR }))));
+                        border-bottom: 1px solid var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_DIVIDER_COLOR }, var(${ CSS_VARIABLES.DIVIDER_COLOR }));
                     }
                     & ${ SELECTOR.ITEM } {
                         & > ${ ELEMENT.PAPER_ICON_ITEM } {
@@ -678,6 +680,9 @@ class CustomSidebar {
                             background-color: var(${CSS_VARIABLES.CUSTOM_SIDEBAR_NOTIFICATION_COLOR}, var(--accent-color));
                         }
                     }
+                    & ${ SELECTOR.DIVIDER }::before {
+                        background-color: var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_DIVIDER_COLOR }, var(${ CSS_VARIABLES.DIVIDER_COLOR }));
+                    }
                 }
                 :host([expanded]) {
                     ${ ELEMENT.PAPER_LISTBOX } {
@@ -706,6 +711,7 @@ class CustomSidebar {
                             &${ SELECTOR.ITEM_SELECTED } {
                                 & > ${ ELEMENT.PAPER_ICON_ITEM } {
                                     & > ${ SELECTOR.ITEM_TEXT } {
+                                        z-index: 1;
                                         &[data-info]::after {
                                             color: var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_SELECTED_INFO_COLOR }, var(${ CSS_VARIABLES.SIDEBAR_SELECTED_TEXT_COLOR }));
                                         }

--- a/src/custom-sidebar.ts
+++ b/src/custom-sidebar.ts
@@ -573,7 +573,8 @@ class CustomSidebar {
                     ['selection_color',       CSS_VARIABLES.CUSTOM_SIDEBAR_SELECTION_COLOR],
                     ['info_color',            CSS_VARIABLES.CUSTOM_SIDEBAR_INFO_COLOR],
                     ['info_color_selected',   CSS_VARIABLES.CUSTOM_SIDEBAR_SELECTED_INFO_COLOR],
-                    ['notification_color',    CSS_VARIABLES.CUSTOM_SIDEBAR_NOTIFICATION_COLOR]
+                    ['notification_color',    CSS_VARIABLES.CUSTOM_SIDEBAR_NOTIFICATION_COLOR],
+                    ['selection_opacity',     CSS_VARIABLES.CUSTOM_SIDEBAR_SELECTION_OPACITY]
                 ]
             );
 
@@ -631,6 +632,7 @@ class CustomSidebar {
                         & > ${ ELEMENT.PAPER_ICON_ITEM } {
                             &::before {
                                 background-color: var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_SELECTION_COLOR }, var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_SELECTED_ICON_COLOR }, var(${ CSS_VARIABLES.SIDEBAR_SELECTED_ICON_COLOR })));
+                                opacity: var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_SELECTION_OPACITY }, 0.12);
                             }
                         }
                         &[${ ATTRIBUTE.WITH_NOTIFICATION }] {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -97,6 +97,7 @@ interface BaseConfig extends ColorConfig {
     sidebar_background?: string;
     sidebar_button_color?: string;
     menu_background?: string;
+    divider_color?: string;
     styles?: string;
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -56,6 +56,7 @@ interface ColorConfig {
     text_color?: string;
     text_color_selected?: string;
     selection_color?: string;
+    selection_opacity?: number | string;
     info_color?: string;
     info_color_selected?: string;
     notification_color?: string;

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -30,7 +30,8 @@ const EXTENDABLE_OPTIONS = [
     'info_color',
     'info_color_selected',
     'notification_color',
-    'selection_opacity'
+    'selection_opacity',
+    'divider_color'
 ] as const;
 
 type ExtendableConfigOption = typeof EXTENDABLE_OPTIONS[number];

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -29,7 +29,8 @@ const EXTENDABLE_OPTIONS = [
     'selection_color',
     'info_color',
     'info_color_selected',
-    'notification_color'
+    'notification_color',
+    'selection_opacity'
 ] as const;
 
 type ExtendableConfigOption = typeof EXTENDABLE_OPTIONS[number];
@@ -50,7 +51,7 @@ const extendOptionsFromBase = (
     extendFromBase: boolean
 ): ExtendableConfigOptions => {
 
-    const configCommonProps: Record<string, string | boolean> = {};
+    const configCommonProps: Record<string, string | boolean | number> = {};
 
     EXTENDABLE_OPTIONS.forEach((option: ExtendableConfigOption): void => {
         const lasExceptionValue = lastException?.[option];

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -8,6 +8,7 @@ import {
     BOOLEAN_TYPE,
     STRING_TYPE,
     UNDEFINED_TYPE,
+    NUMBER_TYPE,
     SIDEBAR_MODE_TO_DOCKED_SIDEBAR
 } from '@constants';
 
@@ -100,6 +101,14 @@ const validateExceptionItem = (exception: ConfigException): void => {
     }
 
     if (
+        typeof exception.selection_opacity !== UNDEFINED_TYPE &&
+        typeof exception.selection_opacity !== NUMBER_TYPE &&
+        typeof exception.selection_opacity !== STRING_TYPE
+    ) {
+        throw new SyntaxError(`${ERROR_PREFIX}, exceptions "selection_opacity" property should be a number or a template string`);
+    }
+
+    if (
         exception.user &&
         exception.not_user
     ) {
@@ -149,6 +158,14 @@ const validateConfigItem = (configItem: ConfigItem): void => {
         `${ERROR_PREFIX} in ${configItem.item},`
     );
 
+    if (
+        typeof configItem.selection_opacity !== UNDEFINED_TYPE &&
+        typeof configItem.selection_opacity !== NUMBER_TYPE &&
+        typeof configItem.selection_opacity !== STRING_TYPE
+    ) {
+        throw new SyntaxError(`${ERROR_PREFIX} in ${configItem.item}, "selection_opacity" property should be a number or a template string`);
+    }
+
     if (configItem.new_item) {
         validateStringOptions(
             configItem,
@@ -185,6 +202,13 @@ export const validateConfig = (config: Config): void => {
         ],
         `${ERROR_PREFIX},`
     );
+    if (
+        typeof config.selection_opacity !== UNDEFINED_TYPE &&
+        typeof config.selection_opacity !== NUMBER_TYPE &&
+        typeof config.selection_opacity !== STRING_TYPE
+    ) {
+        throw new SyntaxError(`${ERROR_PREFIX}, "selection_opacity" property should be a number or a template string`);
+    }
     if (
         typeof config.sidebar_editable !== UNDEFINED_TYPE &&
         typeof config.sidebar_editable !== BOOLEAN_TYPE &&

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -63,6 +63,7 @@ const validateExceptionItem = (exception: ConfigException): void => {
             'title_color',
             'sidebar_button_color',
             'menu_background',
+            'divider_color',
             'styles'
         ],
         `${ERROR_PREFIX}, exceptions`
@@ -198,6 +199,7 @@ export const validateConfig = (config: Config): void => {
             'title_color',
             'sidebar_button_color',
             'menu_background',
+            'divider_color',
             'styles'
         ],
         `${ERROR_PREFIX},`

--- a/tests/10 - validator-errors.spec.ts
+++ b/tests/10 - validator-errors.spec.ts
@@ -12,8 +12,7 @@ test.describe('main options', () => {
         const errors: string[] = [];
 
         await fulfillJson(page, {
-            title: ['Custom Title'],
-            order: {}
+            title: ['Custom Title']
         });
 
         page.on('pageerror', error => {
@@ -35,7 +34,6 @@ test.describe('main options', () => {
         const errors: string[] = [];
 
         await fulfillJson(page, {
-            order: [],
             sidebar_editable: { editable: true }
         });
 
@@ -58,7 +56,6 @@ test.describe('main options', () => {
         const errors: string[] = [];
 
         await fulfillJson(page, {
-            order: {},
             sidebar_mode: 'non_valid'
         });
 
@@ -76,12 +73,33 @@ test.describe('main options', () => {
 
     });
 
+    test('should throw an error if it has a malformed selection_opacity option', async ({ page }) => {
+
+        const errors: string[] = [];
+
+        await fulfillJson(page, {
+            selection_opacity: [100]
+        });
+
+        page.on('pageerror', error => {
+            errors.push(error.message);
+        });
+
+        await page.goto('/');
+        await expect(page.locator(SELECTORS.HA_SIDEBAR)).toBeVisible();
+        expect(errors).toEqual(
+            expect.arrayContaining([
+                `${ERROR_PREFIX}, "selection_opacity" property should be a number or a template string`
+            ])
+        );
+
+    });
+
     test('should throw an error if it has a malformed styles option', async ({ page }) => {
 
         const errors: string[] = [];
 
         await fulfillJson(page, {
-            order: {},
             styles: {
                 body: {
                     color: 'red'
@@ -279,6 +297,33 @@ test.describe('order item property', () => {
 
     });
 
+    test('should throw an error if the "selection_opacity" of an item is not a number or a string', async ({ page }) => {
+
+        const errors: string[] = [];
+
+        await fulfillJson(page, {
+            order: [
+                {
+                    item: 'config',
+                    selection_opacity: { opacity: 1 }
+                }
+            ]
+        });
+
+        page.on('pageerror', error => {
+            errors.push(error.message);
+        });
+
+        await page.goto('/');
+        await expect(page.locator(SELECTORS.HA_SIDEBAR)).toBeVisible();
+        expect(errors).toEqual(
+            expect.arrayContaining([
+                `${ERROR_PREFIX} in config, "selection_opacity" property should be a number or a template string`
+            ])
+        );
+
+    });
+
     test('should throw an error if the "icon" property of a new icon is not a string', async ({ page }) => {
 
         const errors: string[] = [];
@@ -320,7 +365,6 @@ test.describe('exceptions', () => {
         const errors: string[] = [];
 
         await fulfillJson(page, {
-            order: [],
             exceptions: {}
         });
 
@@ -343,7 +387,6 @@ test.describe('exceptions', () => {
         const errors: string[] = [];
 
         await fulfillJson(page, {
-            order: [],
             exceptions: [
                 {
                     order: 100,
@@ -371,7 +414,6 @@ test.describe('exceptions', () => {
         const errors: string[] = [];
 
         await fulfillJson(page, {
-            order: [],
             exceptions: [
                 {
                     title: ['Invalid title']
@@ -398,7 +440,6 @@ test.describe('exceptions', () => {
         const errors: string[] = [];
 
         await fulfillJson(page, {
-            order: [],
             exceptions: [
                 {
                     sidebar_mode: 'non-valid'
@@ -425,7 +466,6 @@ test.describe('exceptions', () => {
         const errors: string[] = [];
 
         await fulfillJson(page, {
-            order: [],
             exceptions: [
                 {
                     sidebar_editable: NaN
@@ -447,12 +487,37 @@ test.describe('exceptions', () => {
 
     });
 
+    test('should throw an error if it has an invalid "selection_opacity" option', async ({ page }) => {
+
+        const errors: string[] = [];
+
+        await fulfillJson(page, {
+            exceptions: [
+                {
+                    selection_opacity: /opacity/
+                }
+            ]
+        });
+
+        page.on('pageerror', error => {
+            errors.push(error.message);
+        });
+
+        await page.goto('/');
+        await expect(page.locator(SELECTORS.HA_SIDEBAR)).toBeVisible();
+        expect(errors).toEqual(
+            expect.arrayContaining([
+                `${ERROR_PREFIX}, exceptions "selection_opacity" property should be a number or a template string`
+            ])
+        );
+
+    });
+
     test('should throw an error if it has an invalid "styles" option', async ({ page }) => {
 
         const errors: string[] = [];
 
         await fulfillJson(page, {
-            order: [],
             exceptions: [
                 {
                     styles: { body: 'display: none' }
@@ -479,10 +544,8 @@ test.describe('exceptions', () => {
         const errors: string[] = [];
 
         await fulfillJson(page, {
-            order: [],
             exceptions: [
                 {
-                    order: [],
                     user: {}
                 }
             ]
@@ -507,10 +570,8 @@ test.describe('exceptions', () => {
         const errors: string[] = [];
 
         await fulfillJson(page, {
-            order: [],
             exceptions: [
                 {
-                    order: [],
                     not_user: {}
                 }
             ]
@@ -535,10 +596,8 @@ test.describe('exceptions', () => {
         const errors: string[] = [];
 
         await fulfillJson(page, {
-            order: [],
             exceptions: [
                 {
-                    order: [],
                     device: 5
                 }
             ]
@@ -563,10 +622,8 @@ test.describe('exceptions', () => {
         const errors: string[] = [];
 
         await fulfillJson(page, {
-            order: [],
             exceptions: [
                 {
-                    order: [],
                     not_device: NaN
                 }
             ]
@@ -591,10 +648,8 @@ test.describe('exceptions', () => {
         const errors: string[] = [];
 
         await fulfillJson(page, {
-            order: [],
             exceptions: [
                 {
-                    order: [],
                     user: 'ElChiniNet',
                     not_user: 'Palaus'
                 }
@@ -620,10 +675,8 @@ test.describe('exceptions', () => {
         const errors: string[] = [];
 
         await fulfillJson(page, {
-            order: [],
             exceptions: [
                 {
-                    order: [],
                     device: ['iPhone'],
                     not_device: ['Android']
                 }
@@ -649,7 +702,6 @@ test.describe('exceptions', () => {
         const errors: string[] = [];
 
         await fulfillJson(page, {
-            order: [],
             exceptions: [
                 {
                     order: [


### PR DESCRIPTION
This pull request adds two new configuration options:

| Property           | Type                               | Required | Description |
| ------------------ | ---------------------------------- | -------- | ----------- |
| selection_opacity<sup>\*</sup> | Number or String       | no       | Sets the opacity of the selected item background. If it is not specified, the default 0.12 will be used |
| divider_color<sup>\*</sup>       | String               | no       | Sets the color of the sidebar dividers |