### PR TITLE
Add a notification_text_color option

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Add a file named `sidebar-config.yaml` or `sidebar-config.json` into your `<conf
 | info_color<sup>\*</sup> | String                        | no       | Sets the color of the info texts of the sidebar items |
 | info_color_selected<sup>\*</sup> | String               | no       | Sets the color of the info text of the selected sidebar item |
 | notification_color<sup>\*</sup>  | String               | no       | Sets the color of the sidebar notifications |
+| notification_text_color<sup>\*</sup>  | String          | no       | Sets the color of the sidebar notifications texts |
 | divider_color<sup>\*</sup>       | String               | no       | Sets the color of the sidebar dividers |
 | styles             | String                             | no       | Custom styles that will be added to the styles block of the plugin. Useful to override styles |
 
@@ -175,6 +176,7 @@ Add a file named `sidebar-config.yaml` or `sidebar-config.json` into your `<conf
 | info_color<sup>\*</sup> | String | no           | Sets the color of the info text (it overrides the global `info_color`) |
 | info_color_selected<sup>\*</sup> | String | no  | Sets the color of the info text when the item is selected (it overrides the global `info_color_selected`) |
 | notification_color<sup>\*</sup>  | String | no  | Sets the notification color (it overrides the global `notification_color`) |
+| notification_text_color<sup>\*</sup>  | String  | no       | Sets the color of the sidebar notification text (it overrides the global `notification_text_color`) |
 | order                     | Number  | no        | Sets the order number of the sidebar item |
 | bottom                    | Boolean | no        | Setting this property to `true` will group the item with the bottom items (Configuration, Developer Tools, etc) |
 | hide                      | Boolean | no        | Setting this property to `true` will hide the sidebar item |

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -52,6 +52,8 @@ export enum CSS_VARIABLES {
     SIDEBAR_TITLE_COLOR = '--sidebar-menu-button-text-color',
     SIDEBAR_BUTTON_COLOR = '--sidebar-icon-color',
     SIDEBAR_MENU_BUTTON_BACKGROUND_COLOR = '--sidebar-menu-button-background-color',
+    TEXT_ACCENT_COLOR = '--text-accent-color',
+    TEXT_PRIMARY_COLOR = '--text-primary-color',
     PRIMARY_BACKGROUND_COLOR = '--primary-background-color',
     DIVIDER_COLOR = '--divider-color',
     CUSTOM_SIDEBAR_BACKGROUND = '--custom-sidebar-background',
@@ -64,6 +66,7 @@ export enum CSS_VARIABLES {
     CUSTOM_SIDEBAR_INFO_COLOR = '--custom-sidebar-info-color',
     CUSTOM_SIDEBAR_SELECTED_INFO_COLOR = '--custom-sidebar-selected-info-color',
     CUSTOM_SIDEBAR_NOTIFICATION_COLOR = '--custom-sidebar-notification-color',
+    CUSTOM_SIDEBAR_NOTIFICATION_TEXT_COLOR = '--custom-sidebar-notification-text-color',
     CUSTOM_SIDEBAR_SELECTION_OPACITY = '--custom-sidebar-selection-opacity',
     CUSTOM_SIDEBAR_DIVIDER_COLOR = '--custom-sidebar-divider-color'
 }

--- a/src/custom-sidebar.ts
+++ b/src/custom-sidebar.ts
@@ -564,18 +564,19 @@ class CustomSidebar {
                 this._configWithExceptions,
                 sidebar,
                 [
-                    ['sidebar_background',    CSS_VARIABLES.CUSTOM_SIDEBAR_BACKGROUND],
-                    ['menu_background',       CSS_VARIABLES.CUSTOM_SIDEBAR_MENU_BACKGROUND],
-                    ['icon_color',            CSS_VARIABLES.CUSTOM_SIDEBAR_ICON_COLOR],
-                    ['icon_color_selected',   CSS_VARIABLES.CUSTOM_SIDEBAR_SELECTED_ICON_COLOR],
-                    ['text_color',            CSS_VARIABLES.CUSTOM_SIDEBAR_TEXT_COLOR],
-                    ['text_color_selected',   CSS_VARIABLES.CUSTOM_SIDEBAR_SELECTED_TEXT_COLOR],
-                    ['selection_color',       CSS_VARIABLES.CUSTOM_SIDEBAR_SELECTION_COLOR],
-                    ['info_color',            CSS_VARIABLES.CUSTOM_SIDEBAR_INFO_COLOR],
-                    ['info_color_selected',   CSS_VARIABLES.CUSTOM_SIDEBAR_SELECTED_INFO_COLOR],
-                    ['notification_color',    CSS_VARIABLES.CUSTOM_SIDEBAR_NOTIFICATION_COLOR],
-                    ['selection_opacity',     CSS_VARIABLES.CUSTOM_SIDEBAR_SELECTION_OPACITY],
-                    ['divider_color',         CSS_VARIABLES.CUSTOM_SIDEBAR_DIVIDER_COLOR]
+                    ['sidebar_background',      CSS_VARIABLES.CUSTOM_SIDEBAR_BACKGROUND],
+                    ['menu_background',         CSS_VARIABLES.CUSTOM_SIDEBAR_MENU_BACKGROUND],
+                    ['icon_color',              CSS_VARIABLES.CUSTOM_SIDEBAR_ICON_COLOR],
+                    ['icon_color_selected',     CSS_VARIABLES.CUSTOM_SIDEBAR_SELECTED_ICON_COLOR],
+                    ['text_color',              CSS_VARIABLES.CUSTOM_SIDEBAR_TEXT_COLOR],
+                    ['text_color_selected',     CSS_VARIABLES.CUSTOM_SIDEBAR_SELECTED_TEXT_COLOR],
+                    ['selection_color',         CSS_VARIABLES.CUSTOM_SIDEBAR_SELECTION_COLOR],
+                    ['info_color',              CSS_VARIABLES.CUSTOM_SIDEBAR_INFO_COLOR],
+                    ['info_color_selected',     CSS_VARIABLES.CUSTOM_SIDEBAR_SELECTED_INFO_COLOR],
+                    ['notification_color',      CSS_VARIABLES.CUSTOM_SIDEBAR_NOTIFICATION_COLOR],
+                    ['notification_text_color', CSS_VARIABLES.CUSTOM_SIDEBAR_NOTIFICATION_TEXT_COLOR],
+                    ['selection_opacity',       CSS_VARIABLES.CUSTOM_SIDEBAR_SELECTION_OPACITY],
+                    ['divider_color',           CSS_VARIABLES.CUSTOM_SIDEBAR_DIVIDER_COLOR]
                 ]
             );
 
@@ -615,6 +616,7 @@ class CustomSidebar {
             const commonNotificationStyles = `
                 background-color: var(${CSS_VARIABLES.CUSTOM_SIDEBAR_NOTIFICATION_COLOR}, var(--accent-color));
                 border-radius: 20px;
+                color: var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_NOTIFICATION_TEXT_COLOR }, var(${ CSS_VARIABLES.TEXT_ACCENT_COLOR }, var(${ CSS_VARIABLES.TEXT_PRIMARY_COLOR })));
                 font-size: 0.65em;
                 overflow: hidden;
                 padding: 0px 5px;
@@ -678,6 +680,7 @@ class CustomSidebar {
                         }
                         & > ${ SELECTOR.CONFIGURATION_BADGE } {
                             background-color: var(${CSS_VARIABLES.CUSTOM_SIDEBAR_NOTIFICATION_COLOR}, var(--accent-color));
+                            color: var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_NOTIFICATION_TEXT_COLOR }, var(${ CSS_VARIABLES.TEXT_ACCENT_COLOR }, var(${ CSS_VARIABLES.TEXT_PRIMARY_COLOR })));
                         }
                     }
                     & ${ SELECTOR.DIVIDER }::before {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -60,6 +60,7 @@ interface ColorConfig {
     info_color?: string;
     info_color_selected?: string;
     notification_color?: string;
+    notification_text_color?: string;
 }
 
 export interface ConfigItem extends ColorConfig {

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -30,6 +30,7 @@ const EXTENDABLE_OPTIONS = [
     'info_color',
     'info_color_selected',
     'notification_color',
+    'notification_text_color',
     'selection_opacity',
     'divider_color'
 ] as const;

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -59,6 +59,7 @@ const validateExceptionItem = (exception: ConfigException): void => {
             'info_color',
             'info_color_selected',
             'notification_color',
+            'notification_text_color',
             'sidebar_background',
             'title_color',
             'sidebar_button_color',
@@ -154,7 +155,8 @@ const validateConfigItem = (configItem: ConfigItem): void => {
             'selection_color',
             'info_color',
             'info_color_selected',
-            'notification_color'
+            'notification_color',
+            'notification_text_color'
         ],
         `${ERROR_PREFIX} in ${configItem.item},`
     );
@@ -195,6 +197,7 @@ export const validateConfig = (config: Config): void => {
             'info_color',
             'info_color_selected',
             'notification_color',
+            'notification_text_color',
             'sidebar_background',
             'title_color',
             'sidebar_button_color',


### PR DESCRIPTION
This pull request adds a new configuration option:

| Property           | Type                               | Required | Description |
| ------------------ | ---------------------------------- | -------- | ----------- |
| notification_text_color<sup>\*</sup>  | String          | no       | Sets the color of the sidebar notifications texts |