### PR TITLE
Fix styles in Safari

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Add a file named `sidebar-config.yaml` or `sidebar-config.json` into your `<conf
 | text_color<sup>\*</sup> | String                        | no       | Sets the text color of the sidebar items |
 | text_color_selected<sup>\*</sup> | String               | no       | Sets the text color of the selected sidebar item |
 | selection_color<sup>\*</sup> | String                   | no       | Sets the color of the selected item background. If it is not specified, the `icon_color_selected` will be used |
-| selection_opacity<sup>\*</sup> | Number or String       | no       | Sets the opacity of the selected item background. If it is not specified, the default 0.12 will be used |
+| selection_opacity<sup>\*</sup> | Number or String       | no       | Sets the opacity of the selected item background. It should be a number between `0` (fully transparent) and `1` (fully opaque). If it is not specified, the default `0.12` will be used |
 | info_color<sup>\*</sup> | String                        | no       | Sets the color of the info texts of the sidebar items |
 | info_color_selected<sup>\*</sup> | String               | no       | Sets the color of the info text of the selected sidebar item |
 | notification_color<sup>\*</sup>  | String               | no       | Sets the color of the sidebar notifications |
@@ -172,7 +172,7 @@ Add a file named `sidebar-config.yaml` or `sidebar-config.json` into your `<conf
 | text_color<sup>\*</sup> | String    | no        | Sets the text color of the item (it overrides the global `text_color`) |
 | text_color_selected<sup>\*</sup> | String | no  | Sets the text color of the item when it is selected (it overrides the global `text_color_selected`) |
 | selection_color<sup>\*</sup> | String     | no  | Sets the color of the item background when it is selected. If it is not specified, the `icon_color_selected` will be used (it overrides the global `selection_color`) |
-| selection_opacity<sup>\*</sup> | Number or String | no       | Sets the opacity of the item background when it is selected. If it is not specified, the default 0.12 will be used (it overrides the global `selection_opacity`) |
+| selection_opacity<sup>\*</sup> | Number or String | no       | Sets the opacity of the item background when it is selected. It should be a number between `0` (fully transparent) and `1` (fully opaque). If it is not specified, the default `0.12` will be used (it overrides the global `selection_opacity`) |
 | info_color<sup>\*</sup> | String | no           | Sets the color of the info text (it overrides the global `info_color`) |
 | info_color_selected<sup>\*</sup> | String | no  | Sets the color of the info text when the item is selected (it overrides the global `info_color_selected`) |
 | notification_color<sup>\*</sup>  | String | no  | Sets the notification color (it overrides the global `notification_color`) |

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -25,6 +25,8 @@ export enum ELEMENT {
 }
 
 export enum SELECTOR {
+    HOST = ':host',
+    HOST_EXPANDED = ':host([expanded])',
     SCOPE = ':scope',
     TITLE = '.title',
     ITEM = 'a[role="option"]',

--- a/src/custom-sidebar.ts
+++ b/src/custom-sidebar.ts
@@ -634,109 +634,84 @@ class CustomSidebar {
 
             addStyle(
                 `
-                :host {
+                ${ SELECTOR.HOST } {
                     background: var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_BACKGROUND }, var(${ CSS_VARIABLES.SIDEBAR_BACKGROUND_COLOR })) !important;
-                    & ${ SELECTOR.MENU } {
-                        background: var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_MENU_BACKGROUND }, var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_BACKGROUND }, var(${ CSS_VARIABLES.SIDEBAR_MENU_BUTTON_BACKGROUND_COLOR }, var(${ CSS_VARIABLES.PRIMARY_BACKGROUND_COLOR }))));
-                        border-bottom: 1px solid var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_DIVIDER_COLOR }, var(${ CSS_VARIABLES.DIVIDER_COLOR }));
-                    }
-                    & ${ SELECTOR.ITEM } {
-                        & > ${ ELEMENT.PAPER_ICON_ITEM } {
-                            &::before {
-                                background-color: var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_SELECTION_COLOR }, var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_SELECTED_ICON_COLOR }, var(${ CSS_VARIABLES.SIDEBAR_SELECTED_ICON_COLOR })));
-                                opacity: var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_SELECTION_OPACITY }, 0.12);
-                            }
-                        }
-                        &[${ ATTRIBUTE.WITH_NOTIFICATION }] {
-                            & > ${ ELEMENT.PAPER_ICON_ITEM } {
-                                & > ${ SELECTOR.ITEM_TEXT } {
-                                    max-width: calc(100% - 86px);
-                                }
-                            }
-                        }
-                    }
-                    & ${ SELECTOR.ITEM_SELECTED } {
-                        & > ${ ELEMENT.PAPER_ICON_ITEM } {
-                            & > :is(${ ELEMENT.HA_SVG_ICON }, ${ ELEMENT.HA_ICON }) {
-                                color: var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_SELECTED_ICON_COLOR }, var(${ CSS_VARIABLES.SIDEBAR_SELECTED_ICON_COLOR }));
-                            }
-                            & > ${ SELECTOR.ITEM_TEXT } {
-                                color: var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_SELECTED_TEXT_COLOR }, var(${ CSS_VARIABLES.SIDEBAR_SELECTED_TEXT_COLOR }));
-                            }
-                        }
-                    }
-                    ${ ELEMENT.PAPER_ICON_ITEM } {
-                        & > :is(${ ELEMENT.HA_SVG_ICON }, ${ ELEMENT.HA_ICON }) {
-                            color: var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_ICON_COLOR }, var(${ CSS_VARIABLES.SIDEBAR_ICON_COLOR }));
-                        }
-                        & > ${ SELECTOR.ITEM_TEXT } {
-                            color: var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_TEXT_COLOR }, var(${ CSS_VARIABLES.SIDEBAR_TEXT_COLOR }));
-                        }
-                        & > ${ SELECTOR.NOTIFICATION_BADGE } {
-                            &:not(${ SELECTOR.NOTIFICATIONS_BADGE_COLLAPSED }) {
-                                left: calc(var(--app-drawer-width, 248px) - 22px);
-                                max-width: 80px;
-                                transform: translateX(-100%);
-                                ${commonNotificationStyles} 
-                            }
-                        }
-                        & > ${ SELECTOR.NOTIFICATIONS_BADGE_COLLAPSED } {
-                            bottom: 14px;
-                            left: 26px;
-                            max-width: 20px;
-                            ${commonNotificationStyles}
-                        }
-                        & > ${ SELECTOR.CONFIGURATION_BADGE } {
-                            background-color: var(${CSS_VARIABLES.CUSTOM_SIDEBAR_NOTIFICATION_COLOR}, var(--accent-color));
-                            color: var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_NOTIFICATION_TEXT_COLOR }, var(${ CSS_VARIABLES.TEXT_ACCENT_COLOR }, var(${ CSS_VARIABLES.TEXT_PRIMARY_COLOR })));
-                        }
-                    }
-                    & ${ SELECTOR.DIVIDER }::before {
-                        background-color: var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_DIVIDER_COLOR }, var(${ CSS_VARIABLES.DIVIDER_COLOR }));
-                    }
                 }
-                :host([expanded]) {
-                    ${ ELEMENT.PAPER_LISTBOX } {
-                        & > ${ SELECTOR.ITEM } {
-                            & > ${ ELEMENT.PAPER_ICON_ITEM } {
-                                & > ${ SELECTOR.NOTIFICATIONS_BADGE_COLLAPSED } {
-                                    opacity: 0;
-                                }
-                                & > ${ SELECTOR.ITEM_TEXT } {
-                                    display: flex;
-                                    flex-direction: column;
-                                    gap: 5px;
-                                    line-height: 1;
-                                    &::after {
-                                        content: attr(data-info);
-                                        display: none;
-                                        font-size: 11px;
-                                        line-height: 1;
-                                    }
-                                    &[data-info]::after {
-                                        color: var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_INFO_COLOR }, var(${ CSS_VARIABLES.SIDEBAR_TEXT_COLOR }));
-                                        display: block;
-                                    }
-                                }
-                            }
-                            &${ SELECTOR.ITEM_SELECTED } {
-                                & > ${ ELEMENT.PAPER_ICON_ITEM } {
-                                    & > ${ SELECTOR.ITEM_TEXT } {
-                                        z-index: 1;
-                                        &[data-info]::after {
-                                            color: var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_SELECTED_INFO_COLOR }, var(${ CSS_VARIABLES.SIDEBAR_SELECTED_TEXT_COLOR }));
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
+                ${ SELECTOR.HOST } ${ SELECTOR.MENU } {
+                    background: var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_MENU_BACKGROUND }, var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_BACKGROUND }, var(${ CSS_VARIABLES.SIDEBAR_MENU_BUTTON_BACKGROUND_COLOR }, var(${ CSS_VARIABLES.PRIMARY_BACKGROUND_COLOR }))));
+                    border-bottom: 1px solid var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_DIVIDER_COLOR }, var(${ CSS_VARIABLES.DIVIDER_COLOR }));
+                }
+                ${ SELECTOR.HOST } ${ SELECTOR.ITEM } > ${ ELEMENT.PAPER_ICON_ITEM }::before {
+                    background-color: var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_SELECTION_COLOR }, var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_SELECTED_ICON_COLOR }, var(${ CSS_VARIABLES.SIDEBAR_SELECTED_ICON_COLOR })));
+                    opacity: var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_SELECTION_OPACITY }, 0.12);
+                }
+                ${ SELECTOR.HOST } ${ SELECTOR.ITEM }[${ ATTRIBUTE.WITH_NOTIFICATION }] > ${ ELEMENT.PAPER_ICON_ITEM } > ${ SELECTOR.ITEM_TEXT } {
+                    max-width: calc(100% - 100px);
+                }
+                ${ SELECTOR.HOST } ${ SELECTOR.ITEM_SELECTED } > ${ ELEMENT.PAPER_ICON_ITEM } > :is(${ ELEMENT.HA_SVG_ICON }, ${ ELEMENT.HA_ICON }) {
+                    color: var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_SELECTED_ICON_COLOR }, var(${ CSS_VARIABLES.SIDEBAR_SELECTED_ICON_COLOR }));
+                }
+                ${ SELECTOR.HOST } ${ SELECTOR.ITEM_SELECTED } > ${ ELEMENT.PAPER_ICON_ITEM } > ${ SELECTOR.ITEM_TEXT } {
+                    color: var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_SELECTED_TEXT_COLOR }, var(${ CSS_VARIABLES.SIDEBAR_SELECTED_TEXT_COLOR }));
+                }
+                ${ SELECTOR.HOST } ${ ELEMENT.PAPER_ICON_ITEM } > :is(${ ELEMENT.HA_SVG_ICON }, ${ ELEMENT.HA_ICON }) {
+                    color: var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_ICON_COLOR }, var(${ CSS_VARIABLES.SIDEBAR_ICON_COLOR }));
+                }
+                ${ SELECTOR.HOST } ${ ELEMENT.PAPER_ICON_ITEM } > ${ SELECTOR.ITEM_TEXT } {
+                    color: var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_TEXT_COLOR }, var(${ CSS_VARIABLES.SIDEBAR_TEXT_COLOR }));
+                }
+                ${ SELECTOR.HOST } ${ ELEMENT.PAPER_ICON_ITEM } > ${ SELECTOR.NOTIFICATION_BADGE }:not(${ SELECTOR.NOTIFICATIONS_BADGE_COLLAPSED }) {
+                    left: calc(var(--app-drawer-width, 248px) - 22px);
+                    max-width: 80px;
+                    transform: translateX(-100%);
+                    ${commonNotificationStyles}
+                }
+                ${ SELECTOR.HOST } ${ ELEMENT.PAPER_ICON_ITEM } > ${ SELECTOR.NOTIFICATIONS_BADGE_COLLAPSED } {
+                    bottom: 14px;
+                    left: 26px;
+                    max-width: 20px;
+                    ${commonNotificationStyles}
+                }
+                ${ SELECTOR.HOST } ${ ELEMENT.PAPER_ICON_ITEM } > ${ SELECTOR.CONFIGURATION_BADGE } {
+                    background-color: var(${CSS_VARIABLES.CUSTOM_SIDEBAR_NOTIFICATION_COLOR}, var(--accent-color));
+                    color: var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_NOTIFICATION_TEXT_COLOR }, var(${ CSS_VARIABLES.TEXT_ACCENT_COLOR }, var(${ CSS_VARIABLES.TEXT_PRIMARY_COLOR })));
+                }
+                ${ SELECTOR.HOST } ${ SELECTOR.DIVIDER }::before {
+                    background-color: var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_DIVIDER_COLOR }, var(${ CSS_VARIABLES.DIVIDER_COLOR }));
+                }
+                ${ SELECTOR.HOST_EXPANDED } ${ ELEMENT.PAPER_LISTBOX } > ${ SELECTOR.ITEM } > ${ ELEMENT.PAPER_ICON_ITEM } > ${ SELECTOR.NOTIFICATIONS_BADGE_COLLAPSED } {
+                    opacity: 0;
+                }
+                ${ SELECTOR.HOST_EXPANDED } ${ ELEMENT.PAPER_LISTBOX } > ${ SELECTOR.ITEM } > ${ ELEMENT.PAPER_ICON_ITEM } > ${ SELECTOR.ITEM_TEXT } {
+                    display: flex;
+                    flex-direction: column;
+                    gap: 5px;
+                    line-height: 1;
+                }
+                ${ SELECTOR.HOST_EXPANDED } ${ ELEMENT.PAPER_LISTBOX } > ${ SELECTOR.ITEM } > ${ ELEMENT.PAPER_ICON_ITEM } > ${ SELECTOR.ITEM_TEXT }::after {
+                    content: attr(data-info);
+                    display: none;
+                    font-size: 11px;
+                    line-height: 1;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                }
+                ${ SELECTOR.HOST_EXPANDED } ${ ELEMENT.PAPER_LISTBOX } > ${ SELECTOR.ITEM } > ${ ELEMENT.PAPER_ICON_ITEM } > ${ SELECTOR.ITEM_TEXT }[data-info]::after {
+                    color: var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_INFO_COLOR }, var(${ CSS_VARIABLES.SIDEBAR_TEXT_COLOR }));
+                    display: block;
+                }
+                ${ SELECTOR.HOST_EXPANDED } ${ ELEMENT.PAPER_LISTBOX } > ${ SELECTOR.ITEM }${ SELECTOR.ITEM_SELECTED } > ${ ELEMENT.PAPER_ICON_ITEM } > ${ SELECTOR.ITEM_TEXT } {
+                    z-index: 1;
+                }
+                ${ SELECTOR.HOST_EXPANDED } ${ ELEMENT.PAPER_LISTBOX } > ${ SELECTOR.ITEM }${ SELECTOR.ITEM_SELECTED } > ${ ELEMENT.PAPER_ICON_ITEM } > ${ SELECTOR.ITEM_TEXT }[data-info]::after {
+                    color: var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_SELECTED_INFO_COLOR }, var(${ CSS_VARIABLES.SIDEBAR_SELECTED_TEXT_COLOR }));
                 }
                 ${ SELECTOR.MENU }[${ BLOCKED_PROPERTY }] {
                     pointer-events: none;
-                    & > ${ SELECTOR.HA_ICON_BUTTON } {
-                        pointer-events: all;
-                    }
+                }
+                ${ SELECTOR.MENU }[${ BLOCKED_PROPERTY }] > ${ SELECTOR.HA_ICON_BUTTON } {
+                    pointer-events: all;
                 }
                 ${ styles }
                 `.trim(),


### PR DESCRIPTION
At the moment, Safari is bugous when the [:host() function](https://developer.mozilla.org/en-US/docs/Web/CSS/:host_function) is used together with nested CSS selectors. In this pull request, all the nested selectors have been reverted to fix a bug in Safari in which several styles were not applied to the proper elements.

<img width="765" alt="image" src="https://github.com/user-attachments/assets/316aa463-45a0-4503-add8-9f5c12b04a3e">
  

