### PR TITLE
Implement a new option to add partials

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Add a file named `sidebar-config.yaml` or `sidebar-config.json` into your `<conf
 | styles             | String                             | no       | Custom styles that will be added to the styles block of the plugin. Useful to override styles |
 | js_variables       | Object                             | no       | An object containing variales that will be used in [JavaScript templates](#javascript-templates). The variables cannot be templates and they must be strings, numbers or booleans |
 | jinja_variables       | Object                          | no       | An object containing variales that will be used in [Jinja templates](#jinja-templates). The variables cannot be templates and they must be strings, numbers or booleans |
+| partials              | Object                          | no       | An object containing fragments of code that can be included in your templates. Consult [the partial section](#partials) for more info |
 
 >\* These options allow [JavaScript](#javascript-templates) or [Jinja](#jinja-templates) templates.
 
@@ -434,6 +435,112 @@ order:
       "item": "info",
       "name": "Info ({{ state_attr('update.home_assistant_supervisor_update', 'latest_version') }})",
       "info": "OS {{ state_attr('update.home_assistant_operating_system_update', 'latest_version') }}",
+      "href": "/config/info",
+      "icon": "mdi:information-outline"
+    }
+  ]
+}
+```
+
+### Partials
+
+Partials are fragments of code that can be included in your templates. They can be inserted in [JavaScript](#javascript-templates) or [Jinja](#jinja-templates) templates and any entity used in them will make the template in which the partial is inserted to be reevaluated when the entity changes its state. Partials can also use variables set in the `js_variables` or `jinja_variables` (depending on the kind of template in which they are inserted).
+
+#### Partials example with a JavaScript template
+
+##### in `YAML` format:
+
+```yaml
+js_variables:
+  supervisor_update: update.home_assistant_supervisor_update
+  os_update: update.home_assistant_operating_system_update
+partials:
+  updates: |
+    const supervisorVersion = state_attr(supervisor_update, "latest_version");
+    const osVersion = state_attr(os_update, "latest_version");
+order:
+  - new_item: true
+    item: info
+    name: |
+      [[[
+        @partial updates
+        return `Info ${supervisorVersion}`;
+      ]]]
+    info: |
+      [[[
+        @partial updates
+        return `OS ${ osVersion }`
+      ]]]
+    href: '/config/info'
+    icon: mdi:information-outline
+```
+
+##### in `JSON` format:
+
+```json5
+{
+  "js_variables": {
+    "supervisor_update": "update.home_assistant_supervisor_update",
+    "os_update": "update.home_assistant_operating_system_update"
+  },
+  "partials": {
+    "updates": "const supervisorVersion = state_attr(supervisor_update, 'latest_version'); const osVersion = state_attr(os_update, 'latest_version');"
+  },
+  "order": [
+    {
+      "new_item": true,
+      "item": "info",
+      "name": "[[[ @partial updates return `Info ${supervisorVersion}`; ]]]",
+      "info": "[[[ @partial updates return `OS ${ osVersion }`; ]]]",
+      "href": "/config/info",
+      "icon": "mdi:information-outline"
+    }
+  ]
+}
+```
+
+#### Partials example with a Jinja template
+
+##### in `YAML` format:
+
+```yaml
+jinja_variables:
+  supervisor_update: update.home_assistant_supervisor_update
+  os_update: update.home_assistant_operating_system_update
+partials:
+  updates: |
+    {% set supervisorVersion = state_attr(supervisor_update, "latest_version") %}
+    {% set osVersion = state_attr(os_update, "latest_version") %}
+order:
+  - new_item: true
+    item: info
+    name: |
+        @partial updates
+        Info {{ supervisorVersion }}
+    info: |
+        @partial updates
+        OS {{ osVersion }}
+    href: '/config/info'
+    icon: mdi:information-outline
+```
+
+##### in `JSON` format:
+
+```json5
+{
+  "jinja_variables": {
+    "supervisor_update": "update.home_assistant_supervisor_update",
+    "os_update": "update.home_assistant_operating_system_update"
+  },
+  "partials": {
+    "updates": "{% set supervisorVersion = state_attr(supervisor_update, 'latest_version') %} {% set osVersion = state_attr(os_update, 'latest_version') %}"
+  },
+  "order": [
+    {
+      "new_item": true,
+      "item": "info",
+      "name": "@partial updates Info {{ supervisorVersion }}",
+      "info": "@partial updates OS {{ osVersion }}",
       "href": "/config/info",
       "icon": "mdi:information-outline"
     }

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -137,3 +137,4 @@ export const PROFILE_GENERAL_PATH = '/profile/general';
 export const JS_TEMPLATE_REG = /^\s*\[\[\[([\s\S]+)\]\]\]\s*$/;
 export const JINJA_TEMPLATE_REG = /\{\{[\s\S]*\}\}|\{%[\s\S]*%\}/;
 export const CSS_CLEANER_REGEXP = /(\s*)([\w-]+\s*:\s*[^;]+;?|\})(\s*)/g;
+export const PARTIAL_REGEXP = /@partial\s+([\w-]+)/g;

--- a/src/custom-sidebar.ts
+++ b/src/custom-sidebar.ts
@@ -45,6 +45,7 @@ import {
     getPromisableElement,
     getConfigWithExceptions,
     flushPromise,
+    getTemplateWithPartials,
     addStyle
 } from '@utilities';
 import { fetchConfig } from '@fetchers/json';
@@ -375,12 +376,14 @@ class CustomSidebar {
     }
 
     private _createJsTemplateSubscription(
-        code: string,
+        template: string,
         callback: (result: string) => void
     ): void {
-
         this._renderer.trackTemplate(
-            code,
+            getTemplateWithPartials(
+                template,
+                this._configWithExceptions.partials
+            ),
             (result: unknown): void => {
                 this._getTemplateString(result)
                     .then((templateResult: string) => {
@@ -402,7 +405,10 @@ class CustomSidebar {
                 },
                 {
                     type: EVENT.RENDER_TEMPLATE,
-                    template,
+                    template: getTemplateWithPartials(
+                        template,
+                        this._configWithExceptions.partials
+                    ),
                     variables: {
                         user_name: this._ha.hass.user.name,
                         user_is_admin: this._ha.hass.user.is_admin,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -137,6 +137,7 @@ export interface Config extends BaseConfig {
     id?: string;
     js_variables?: Record<string, Primitive>;
     jinja_variables?: Record<string, Primitive>;
+    partials?: Record<string, string>;
     exceptions?: ConfigException[];
 }
 

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -9,7 +9,8 @@ import {
     MAX_ATTEMPTS,
     RETRY_DELAY,
     FLUSH_PROMISE_DELAY,
-    CSS_CLEANER_REGEXP
+    CSS_CLEANER_REGEXP,
+    PARTIAL_REGEXP
 } from '@constants';
 import { version } from '../../package.json';
 
@@ -37,7 +38,8 @@ const EXTENDABLE_OPTIONS = [
 
 const ONLY_CONFIG_OPTIONS = [
     'js_variables',
-    'jinja_variables'
+    'jinja_variables',
+    'partials'
 ] as const;
 
 type ExtendableConfigOption = typeof EXTENDABLE_OPTIONS[number];
@@ -220,4 +222,17 @@ export const addStyle = (css: string, elem: ShadowRoot): void => {
     style.setAttribute('id', `${NAMESPACE}_${name}`);
     elem.appendChild(style);
     style.innerHTML = css.replace(CSS_CLEANER_REGEXP, '$2');
+};
+
+export const getTemplateWithPartials = (template: string, partials: Record<string, string> | undefined): string => {
+    if (!partials) {
+        return template;
+    }
+    return template.replace(PARTIAL_REGEXP, (__match: string, partial: string): string => {
+        if (partials[partial]) {
+            return partials[partial].trim();
+        }
+        console.warn(`${NAMESPACE}: partial ${partial} doesn't exist`);
+        return '';
+    });
 };

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -260,6 +260,17 @@ export const validateConfig = (config: Config): void => {
     ) {
         throw new SyntaxError(`${ERROR_PREFIX}, "order" property should be an array`);
     }
+    if (typeof config.partials !== TYPE.UNDEFINED) {
+        if (Object.prototype.toString.call(config.partials) !== OBJECT_TO_STRING) {
+            throw new SyntaxError(`${ERROR_PREFIX}, "partials" property should be an object`);
+        }
+        Object.entries(config.partials).forEach((entry) => {
+            const [partial, value] = entry;
+            if (typeof value !== TYPE.STRING) {
+                throw new SyntaxError(`${ERROR_PREFIX}, "partials" should be an object with strings. The partial ${partial} is not a string`);
+            }
+        });
+    }
     validateVariables('js_variables', config.js_variables);
     validateVariables('jinja_variables', config.jinja_variables);
     config.order?.forEach(validateConfigItem);

--- a/tests/12 - validator-errors.spec.ts
+++ b/tests/12 - validator-errors.spec.ts
@@ -36,6 +36,7 @@ const runErrorTests = (tests: TestSuit[]): void => {
             await page.goto('/');
 
             await expect(page.locator(SELECTORS.HA_SIDEBAR)).toBeVisible();
+            await expect(page.locator(SELECTORS.HUI_VIEW)).toBeVisible();
 
             if (error) {
                 expect(errors).toEqual(
@@ -157,6 +158,49 @@ test.describe('main options', () => {
                 }
             },
             warning: '"jinja_variables" property should not have templates. Property TEST_1 seems to be a template'
+        },
+        {
+            title: 'should throw an error if the partials property is not an object',
+            json: {
+                partials: ['partial']
+            },
+            error: `${ERROR_PREFIX}, "partials" property should be an object`
+        },
+        {
+            title: 'should throw an error if a partial inside the partials property is not a string',
+            json: {
+                partials: {
+                    partial_1: 'partial_1',
+                    partial_2: 100
+                }
+            },
+            error: `${ERROR_PREFIX}, "partials" should be an object with strings. The partial partial_2 is not a string`
+        },
+        {
+            title: 'should warn about a non existent partial with a JavaScript template',
+            json: {
+                partials: {
+                    my_partial: 'const title = "Title"'
+                },
+                title: `[[[
+                    @partial your_partial
+                    return 'Title';
+                ]]]`
+            },
+            warning: 'custom-sidebar: partial your_partial doesn\'t exist'
+        },
+        {
+            title: 'should warn about a non existent partial with a Jinja template',
+            json: {
+                partials: {
+                    my_partial: '{% set title = "Title" %}'
+                },
+                title: `
+                    @partial your_partial
+                    {{ title }}
+                `
+            },
+            warning: 'custom-sidebar: partial your_partial doesn\'t exist'
         }
     ]);
 


### PR DESCRIPTION
This pull request implements a new option to include partials in any template.

### Configuration options

| Property           | Type                               | Required | Description |
| ------------------ | ---------------------------------- | -------- | ----------- |
| partials              | Object                          | no       | An object containing fragments of code that can be included in your templates. Consult [the partial section](#partials) for more info |

### Partials

Partials are fragments of code that can be included in your templates. They can be inserted in [JavaScript](https://github.com/elchininet/custom-sidebar?tab=readme-ov-file#javascript-templates) or [Jinja](https://github.com/elchininet/custom-sidebar?tab=readme-ov-file#jinja-templates) templates and any entity used in them will make the template in which the partial is inserted to be reevaluated when the entity changes its state. Partials can also use variables set in the `js_variables` or `jinja_variables` (depending on the kind of template in which they are inserted).

#### Partials example with a JavaScript template

##### in `YAML` format:

```yaml
js_variables:
  supervisor_update: update.home_assistant_supervisor_update
  os_update: update.home_assistant_operating_system_update
partials:
  updates: |
    const supervisorVersion = state_attr(supervisor_update, "latest_version");
    const osVersion = state_attr(os_update, "latest_version");
order:
  - new_item: true
    item: info
    name: |
      [[[
        @partial updates
        return `Info ${supervisorVersion}`;
      ]]]
    info: |
      [[[
        @partial updates
        return `OS ${ osVersion }`
      ]]]
    href: '/config/info'
    icon: mdi:information-outline
```

##### in `JSON` format:

```json5
{
  "js_variables": {
    "supervisor_update": "update.home_assistant_supervisor_update",
    "os_update": "update.home_assistant_operating_system_update"
  },
  "partials": {
    "updates": "const supervisorVersion = state_attr(supervisor_update, 'latest_version'); const osVersion = state_attr(os_update, 'latest_version');"
  },
  "order": [
    {
      "new_item": true,
      "item": "info",
      "name": "[[[ @partial updates return `Info ${supervisorVersion}`; ]]]",
      "info": "[[[ @partial updates return `OS ${ osVersion }`; ]]]",
      "href": "/config/info",
      "icon": "mdi:information-outline"
    }
  ]
}
```

#### Partials example with a Jinja template

##### in `YAML` format:

```yaml
jinja_variables:
  supervisor_update: update.home_assistant_supervisor_update
  os_update: update.home_assistant_operating_system_update
partials:
  updates: |
    {% set supervisorVersion = state_attr(supervisor_update, "latest_version") %}
    {% set osVersion = state_attr(os_update, "latest_version") %}
order:
  - new_item: true
    item: info
    name: |
        @partial updates
        Info {{ supervisorVersion }}
    info: |
        @partial updates
        OS {{ osVersion }}
    href: '/config/info'
    icon: mdi:information-outline
```

##### in `JSON` format:

```json5
{
  "jinja_variables": {
    "supervisor_update": "update.home_assistant_supervisor_update",
    "os_update": "update.home_assistant_operating_system_update"
  },
  "partials": {
    "updates": "{% set supervisorVersion = state_attr(supervisor_update, 'latest_version') %} {% set osVersion = state_attr(os_update, 'latest_version') %}"
  },
  "order": [
    {
      "new_item": true,
      "item": "info",
      "name": "@partial updates Info {{ supervisorVersion }}",
      "info": "@partial updates OS {{ osVersion }}",
      "href": "/config/info",
      "icon": "mdi:information-outline"
    }
  ]
}
```