### PR TITLE
Make it possible to insert a partial inside another partial

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,7 +444,9 @@ order:
 
 ### Partials
 
-Partials are fragments of code that can be included in your templates. They can be inserted in [JavaScript](#javascript-templates) or [Jinja](#jinja-templates) templates and any entity used in them will make the template in which the partial is inserted to be reevaluated when the entity changes its state. Partials can also use variables set in the `js_variables` or `jinja_variables` (depending on the kind of template in which they are inserted).
+Partials are fragments of code that can be included in your templates. They can be inserted in [JavaScript](#javascript-templates), [Jinja](#jinja-templates) templates or inside another partial. Any entity used in them will make the template in which the partial is inserted to be reevaluated when the entity changes its state.
+
+>Note: Partials will automatically use the variables set in the `js_variables` or `jinja_variables` (depending on the kind of template in which they are inserted).
 
 #### Partials example with a JavaScript template
 
@@ -455,8 +457,10 @@ js_variables:
   supervisor_update: update.home_assistant_supervisor_update
   os_update: update.home_assistant_operating_system_update
 partials:
-  updates: |
+  supervisor_version: |
     const supervisorVersion = state_attr(supervisor_update, "latest_version");
+  updates: |
+    @partial supervisor_version
     const osVersion = state_attr(os_update, "latest_version");
 order:
   - new_item: true
@@ -484,7 +488,8 @@ order:
     "os_update": "update.home_assistant_operating_system_update"
   },
   "partials": {
-    "updates": "const supervisorVersion = state_attr(supervisor_update, 'latest_version'); const osVersion = state_attr(os_update, 'latest_version');"
+    "supervisor_version": "const supervisorVersion = state_attr(supervisor_update, 'latest_version');",
+    "updates": "@partial supervisor_version const osVersion = state_attr(os_update, 'latest_version');"
   },
   "order": [
     {
@@ -508,8 +513,10 @@ jinja_variables:
   supervisor_update: update.home_assistant_supervisor_update
   os_update: update.home_assistant_operating_system_update
 partials:
-  updates: |
+  supervisor_version: |
     {% set supervisorVersion = state_attr(supervisor_update, "latest_version") %}
+  updates: |
+    @partial supervisor_version
     {% set osVersion = state_attr(os_update, "latest_version") %}
 order:
   - new_item: true
@@ -533,7 +540,8 @@ order:
     "os_update": "update.home_assistant_operating_system_update"
   },
   "partials": {
-    "updates": "{% set supervisorVersion = state_attr(supervisor_update, 'latest_version') %} {% set osVersion = state_attr(os_update, 'latest_version') %}"
+    "supervisor_version": "{% set supervisorVersion = state_attr(supervisor_update, 'latest_version') %}",
+    "updates": "@partial supervisor_version {% set osVersion = state_attr(os_update, 'latest_version') %}"
   },
   "order": [
     {

--- a/tests/12 - validator-errors.spec.ts
+++ b/tests/12 - validator-errors.spec.ts
@@ -190,6 +190,26 @@ test.describe('main options', () => {
             warning: 'custom-sidebar: partial your_partial doesn\'t exist'
         },
         {
+            title: 'should throw an error if there is a circular partial dependency in a JavaScript template',
+            json: {
+                partials: {
+                    my_title: `
+                        @partial my_partial
+                        const title = "Title"
+                    `,
+                    my_partial: `
+                        @partial my_title
+                        const myTitle = title.toUpperCase();
+                    `
+                },
+                title: `[[[
+                    @partial my_partial
+                    return myTitle;
+                ]]]`
+            },
+            error: `custom-sidebar: circular partials dependency my_partial > my_title > my_partial`
+        },
+        {
             title: 'should warn about a non existent partial with a Jinja template',
             json: {
                 partials: {
@@ -201,6 +221,26 @@ test.describe('main options', () => {
                 `
             },
             warning: 'custom-sidebar: partial your_partial doesn\'t exist'
+        },
+        {
+            title: 'should throw an error if there is a circular partial dependency in a Jinja template',
+            json: {
+                partials: {
+                    my_title: `
+                        @partial my_partial
+                        {% set title = "Title" %}
+                    `,
+                    my_partial: `
+                        @partial my_title
+                        {% set myTitle = title | upper %};
+                    `
+                },
+                title: `
+                    @partial my_partial
+                    {{ myTitle }}
+                `
+            },
+            error: `custom-sidebar: circular partials dependency my_partial > my_title > my_partial`
         }
     ]);
 


### PR DESCRIPTION
This pull request make it possible to include partials inside other partials.

Example:

```yaml
js_variables:
  supervisor_update: update.home_assistant_supervisor_update
  os_update: update.home_assistant_operating_system_update
partials:
  supervisor_version: |
    const supervisorVersion = state_attr(supervisor_update, "latest_version");
  updates: |
    @partial supervisor_version
    const osVersion = state_attr(os_update, "latest_version");
order:
  - new_item: true
    item: info
    name: |
      [[[
        @partial updates
        return `Info ${supervisorVersion}`;
      ]]]
    info: |
      [[[
        @partial updates
        return `OS ${ osVersion }`
      ]]]
    href: '/config/info'
    icon: mdi:information-outline
```