### PR TITLE
Start using HomeAssistantStylesManager to manage the styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   "dependencies": {
     "home-assistant-javascript-templates": "^5.4.0",
     "home-assistant-query-selector": "^4.2.0",
+    "home-assistant-styles-manager": "^3.0.0",
     "js-yaml": "^4.1.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       home-assistant-query-selector:
         specifier: ^4.2.0
         version: 4.2.0
+      home-assistant-styles-manager:
+        specifier: ^3.0.0
+        version: 3.0.0
       js-yaml:
         specifier: ^4.1.0
         version: 4.1.0
@@ -981,6 +984,9 @@ packages:
 
   home-assistant-query-selector@4.2.0:
     resolution: {integrity: sha512-8VwrqTunsE3sgakCirBdQgrZTvWgT1SIaVthpgVCeaA/8dUK0qQfn3JFUcwaa8xm0NUa8yDgjRkxKe9lGHA65Q==}
+
+  home-assistant-styles-manager@3.0.0:
+    resolution: {integrity: sha512-h3TZeaRGxcxNNFGWr1VPhiecTqgxRiC053wH1/+3A7CSwD/dQ3EfIb+d5G+udRc5hFxijUk9UQnvT2yTp2UMtA==}
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
@@ -2479,6 +2485,8 @@ snapshots:
   home-assistant-query-selector@4.2.0:
     dependencies:
       shadow-dom-selector: 4.1.2
+
+  home-assistant-styles-manager@3.0.0: {}
 
   html-escaper@2.0.2: {}
 

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -136,5 +136,4 @@ export const PROFILE_GENERAL_PATH = '/profile/general';
 
 export const JS_TEMPLATE_REG = /^\s*\[\[\[([\s\S]+)\]\]\]\s*$/;
 export const JINJA_TEMPLATE_REG = /\{\{[\s\S]*\}\}|\{%[\s\S]*%\}/;
-export const CSS_CLEANER_REGEXP = /(\s*)([\w-]+\s*:\s*[^;]+;?|\})(\s*)/g;
 export const PARTIAL_REGEXP = /@partial\s+([\w-]+)/g;

--- a/src/custom-sidebar.ts
+++ b/src/custom-sidebar.ts
@@ -8,6 +8,7 @@ import HomeAssistantJavaScriptTemplates, {
     HomeAssistantJavaScriptTemplatesRenderer,
     HassConnection
 } from 'home-assistant-javascript-templates';
+import { HomeAssistantStylesManager } from 'home-assistant-styles-manager';
 import {
     HomeAsssistantExtended,
     HomeAssistantMain,
@@ -45,8 +46,7 @@ import {
     getPromisableElement,
     getConfigWithExceptions,
     flushPromise,
-    getTemplateWithPartials,
-    addStyle
+    getTemplateWithPartials
 } from '@utilities';
 import { fetchConfig } from '@fetchers/json';
 
@@ -76,6 +76,12 @@ class CustomSidebar {
 
         selector.listen();
 
+        this._styleManager = new HomeAssistantStylesManager({
+            prefix: NAMESPACE,
+            namespace: NAMESPACE,
+            throwWarnings: false
+        });
+
         this._items = [];
         this._sidebarScroll = 0;
         this._isSidebarEditable = undefined;
@@ -96,6 +102,7 @@ class CustomSidebar {
     private _sidebarScroll: number;
     private _isSidebarEditable: boolean | undefined;
     private _renderer: HomeAssistantJavaScriptTemplatesRenderer;
+    private _styleManager: HomeAssistantStylesManager;
     private _items: ConfigOrderWithItem[];
     private _itemTouchedBinded: () => Promise<void>;
     private _mouseEnterBinded: (event: MouseEvent) => void;
@@ -630,7 +637,7 @@ class CustomSidebar {
                 text-wrap: nowrap;
             `;
 
-            addStyle(
+            this._styleManager.addStyle(
                 `
                 ${ SELECTOR.HOST } {
                     background: var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_BACKGROUND }, var(${ CSS_VARIABLES.SIDEBAR_BACKGROUND_COLOR })) !important;

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -9,7 +9,6 @@ import {
     MAX_ATTEMPTS,
     RETRY_DELAY,
     FLUSH_PROMISE_DELAY,
-    CSS_CLEANER_REGEXP,
     PARTIAL_REGEXP
 } from '@constants';
 import { version } from '../../package.json';
@@ -211,18 +210,6 @@ export const getConfigWithExceptions = (
 export const flushPromise = () => new Promise((resolve) => {
     setTimeout(resolve, FLUSH_PROMISE_DELAY);
 });
-
-const getElementName = (elem: ShadowRoot): string => {
-    return elem.host.localName;
-};
-
-export const addStyle = (css: string, elem: ShadowRoot): void => {
-    const name = getElementName(elem);
-    const style = document.createElement('style');
-    style.setAttribute('id', `${NAMESPACE}_${name}`);
-    elem.appendChild(style);
-    style.innerHTML = css.replace(CSS_CLEANER_REGEXP, '$2');
-};
 
 export const getTemplateWithPartials = (
     template: string,


### PR DESCRIPTION
This pull request removes the custom utility to manage the styles in the plugin and start to use [home-assistant-styles-manager](https://github.com/elchininet/home-assistant-styles-manager) in its place.