### PR TITLE
Remove @partial statements even if there are no partials

### DIFF
--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -216,11 +216,8 @@ export const getTemplateWithPartials = (
     partials: Record<string, string> | undefined,
     tree: string[] = []
 ): string => {
-    if (!partials) {
-        return template;
-    }
     return template.replace(PARTIAL_REGEXP, (__match: string, partial: string): string => {
-        if (partials[partial]) {
+        if (partials?.[partial]) {
             if (tree.includes(partial)) {
                 throw new SyntaxError(`${NAMESPACE}: circular partials dependency ${tree.join(' > ')} > ${ partial }`);
             }


### PR DESCRIPTION
If a `@partial` statement is used without partials, at the moment the same template is returned without being processed. This provokes ending with a template code with an unrecognised `@partial` statement, something that will be hard to debug. In this pull request this behaviour is changed, the `@partial` statements are always removed from the template code and if there are no partials a warning will be thrown stating that the desired partial doesn't exist. This is more informative than the previous behaviour.