### PR TITLE
Remove the local getPromisableElement utility

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "typescript-eslint": "^8.12.2"
   },
   "dependencies": {
+    "get-promisable-result": "^1.0.1",
     "home-assistant-javascript-templates": "^5.4.0",
     "home-assistant-query-selector": "^4.2.0",
     "home-assistant-styles-manager": "^3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      get-promisable-result:
+        specifier: ^1.0.1
+        version: 1.0.1
       home-assistant-javascript-templates:
         specifier: ^5.4.0
         version: 5.4.0
@@ -932,6 +935,9 @@ packages:
   get-package-type@0.1.0:
     resolution: {integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==}
     engines: {node: '>=8.0.0'}
+
+  get-promisable-result@1.0.1:
+    resolution: {integrity: sha512-hUUKs/s8qoeH4gk3NPcKjCWaCjOv0S+kyT3oTuJXneEWYzwmyfEJHESU2ES7pMZNVHTjMt7X8hpmThFfggTVtg==}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -2439,6 +2445,8 @@ snapshots:
   get-caller-file@2.0.5: {}
 
   get-package-type@0.1.0: {}
+
+  get-promisable-result@1.0.1: {}
 
   glob-parent@5.1.2:
     dependencies:

--- a/src/checker.ts
+++ b/src/checker.ts
@@ -1,9 +1,18 @@
-import { NAMESPACE } from '@constants';
-import { getPromisableElement } from '@utilities';
+import { getPromisableResult } from 'get-promisable-result';
+import {
+    NAMESPACE,
+    MAX_ATTEMPTS,
+    RETRY_DELAY
+} from '@constants';
 
-getPromisableElement(
+getPromisableResult(
     () => window.CustomSidebar,
-    (customSideBar: object) => !!customSideBar
+    (customSideBar: object) => !!customSideBar,
+    {
+        retries: MAX_ATTEMPTS,
+        delay: RETRY_DELAY,
+        shouldReject: false
+    }
 ).then((sidebar) => {
     if (!sidebar) {
         throw Error(`${NAMESPACE}: you need to add the plugin as a frontend > extra_module_url module.\nCheck the documentation: https://github.com/elchininet/custom-sidebar#installation`);

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -6,8 +6,6 @@ import {
 import {
     NAMESPACE,
     TYPE,
-    MAX_ATTEMPTS,
-    RETRY_DELAY,
     FLUSH_PROMISE_DELAY,
     PARTIAL_REGEXP
 } from '@constants';
@@ -117,32 +115,6 @@ export const logVersionToConsole = () => {
         'font-weight: bold; background: #EEEEEE; color: #666666; padding: 2px 5px;',
         'font-weight: normal; background: #E87A24; color: #FFFFFF; padding: 2px 5px'
     );
-};
-
-export const getPromisableElement = <T>(
-    getElement: () => T,
-    check: (element: T) => boolean
-): Promise<T> => {
-    return new Promise<T>((resolve) => {
-        let attempts = 0;
-        const select = () => {
-            const element: T = getElement();
-            if (element && check(element)) {
-                resolve(element);
-            } else {
-                attempts++;
-                // The else clause is an edge case that should not happen
-                // Very hard to reproduce so it cannot be covered
-                /* istanbul ignore else */
-                if (attempts < MAX_ATTEMPTS) {
-                    setTimeout(select, RETRY_DELAY);
-                } else {
-                    resolve(element);
-                }
-            }
-        };
-        select();
-    });
 };
 
 export const getConfigWithExceptions = (


### PR DESCRIPTION
This pull request removes the utility `getPromisableElement` and replaces it by the `getPromisableResult` utility from the [get-promisable-result](https://github.com/elchininet/get-promisable-result) package.