### PR TITLE
Refactor CSS variables validation and management

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,4 +1,8 @@
-import{ SidebarMode, DockedSidebar } from '@types';
+import{
+    ColorConfig,
+    SidebarMode,
+    DockedSidebar
+} from '@types';
 
 export const NAMESPACE = 'custom-sidebar';
 export const LOCAL_PATH = '/local/';
@@ -57,41 +61,47 @@ export enum PSEUDO_SELECTOR {
     WEBKIT_SCROLLBAR_THUMB = '::-webkit-scrollbar-thumb'
 }
 
-export enum CSS_VARIABLES {
-    SIDEBAR_ICON_COLOR = '--sidebar-icon-color',
-    SIDEBAR_SELECTED_ICON_COLOR= '--sidebar-selected-icon-color',
-    SIDEBAR_TEXT_COLOR = '--sidebar-text-color',
-    SIDEBAR_SELECTED_TEXT_COLOR = '--sidebar-selected-text-color',
+export enum HA_CSS_VARIABLES {
+    PRIMARY_BACKGROUND_COLOR = '--primary-background-color',
     SIDEBAR_BACKGROUND_COLOR = '--sidebar-background-color',
     SIDEBAR_TITLE_COLOR = '--sidebar-menu-button-text-color',
     SIDEBAR_BUTTON_COLOR = '--sidebar-icon-color',
     SIDEBAR_MENU_BUTTON_BACKGROUND_COLOR = '--sidebar-menu-button-background-color',
+
+    SIDEBAR_ICON_COLOR = '--sidebar-icon-color',
+    SIDEBAR_SELECTED_ICON_COLOR= '--sidebar-selected-icon-color',
+    SIDEBAR_TEXT_COLOR = '--sidebar-text-color',
+    SIDEBAR_SELECTED_TEXT_COLOR = '--sidebar-selected-text-color',
+    ACCENT_COLOR = '--accent-color',
     TEXT_ACCENT_COLOR = '--text-accent-color',
     TEXT_PRIMARY_COLOR = '--text-primary-color',
-    PRIMARY_BACKGROUND_COLOR = '--primary-background-color',
     PRIMARY_TEXT_COLOR = '--primary-text-color',
     DIVIDER_COLOR = '--divider-color',
-    SCROLLBAR_THUMB_COLOR = '--scrollbar-thumb-color',
-    CUSTOM_SIDEBAR_BACKGROUND = '--custom-sidebar-background',
-    CUSTOM_SIDEBAR_BORDER_COLOR = '--custom-sidebar-border-color',
-    CUSTOM_SIDEBAR_MENU_BACKGROUND = '--custom-sidebar-menu-background',
-    CUSTOM_SIDEBAR_TITLE_COLOR = '--custom-sidebar-title-color',
-    CUSTOM_SIDEBAR_SUBTITLE_COLOR = '--custom-sidebar-subtitle-color',
-    CUSTOM_SIDEBAR_BUTTON_COLOR = '--custom-sidebar-button-color',
-    CUSTOM_SIDEBAR_TEXT_COLOR = '--custom-sidebar-text-color',
-    CUSTOM_SIDEBAR_SELECTED_TEXT_COLOR = '--custom-sidebar-selected-text-color',
-    CUSTOM_SIDEBAR_ICON_COLOR = '--custom-sidebar-icon-color',
-    CUSTOM_SIDEBAR_SELECTED_ICON_COLOR = '--custom-sidebar-selected-icon-color',
-    CUSTOM_SIDEBAR_SELECTION_COLOR = '--custom-sidebar-selection-color',
-    CUSTOM_SIDEBAR_INFO_COLOR = '--custom-sidebar-info-color',
-    CUSTOM_SIDEBAR_SELECTED_INFO_COLOR = '--custom-sidebar-selected-info-color',
-    CUSTOM_SIDEBAR_NOTIFICATION_COLOR = '--custom-sidebar-notification-color',
-    CUSTOM_SIDEBAR_NOTIFICATION_TEXT_COLOR = '--custom-sidebar-notification-text-color',
-    CUSTOM_SIDEBAR_SELECTION_OPACITY = '--custom-sidebar-selection-opacity',
-    CUSTOM_SIDEBAR_DIVIDER_COLOR = '--custom-sidebar-divider-color',
-    CUSTOM_SIDEBAR_DIVIDER_TOP_COLOR = '--custom-sidebar-divider-top-color',
-    CUSTOM_SIDEBAR_DIVIDER_BOTTOM_COLOR = '--custom-sidebar-divider-bottom-color',
-    CUSTOM_SIDEBAR_SCROLLBAR_THUMB_COLOR = '--custom-sidebar-scrollbar-thumb-color'
+    SCROLLBAR_THUMB_COLOR = '--scrollbar-thumb-color'
+}
+
+export enum CUSTOM_SIDEBAR_CSS_VARIABLES {
+    BACKGROUND = '--custom-sidebar-background',
+    BORDER_COLOR = '--custom-sidebar-border-color',
+    MENU_BACKGROUND = '--custom-sidebar-menu-background',
+    TITLE_COLOR = '--custom-sidebar-title-color',
+    SUBTITLE_COLOR = '--custom-sidebar-subtitle-color',
+    BUTTON_COLOR = '--custom-sidebar-button-color',
+    DIVIDER_COLOR = '--custom-sidebar-divider-color',
+    DIVIDER_TOP_COLOR = '--custom-sidebar-divider-top-color',
+    DIVIDER_BOTTOM_COLOR = '--custom-sidebar-divider-bottom-color',
+    SCROLLBAR_THUMB_COLOR = '--custom-sidebar-scrollbar-thumb-color',
+
+    ICON_COLOR = '--custom-sidebar-icon-color',
+    TEXT_COLOR = '--custom-sidebar-text-color',
+    SELECTED_TEXT_COLOR = '--custom-sidebar-selected-text-color',
+    SELECTED_ICON_COLOR = '--custom-sidebar-selected-icon-color',
+    SELECTION_COLOR = '--custom-sidebar-selection-color',
+    SELECTION_OPACITY = '--custom-sidebar-selection-opacity',
+    INFO_COLOR = '--custom-sidebar-info-color',
+    SELECTED_INFO_COLOR = '--custom-sidebar-selected-info-color',
+    NOTIFICATION_COLOR = '--custom-sidebar-notification-color',
+    NOTIFICATION_TEXT_COLOR = '--custom-sidebar-notification-text-color'
 }
 
 export enum CLASS {
@@ -111,6 +121,22 @@ export enum ATTRIBUTE {
     HREF = 'href',
     STYLE = 'style'
 }
+
+export const ITEM_TEMPLATE_STRING_OPTIONS: (keyof ColorConfig)[] = [
+    'icon_color',
+    'icon_color_selected',
+    'text_color',
+    'text_color_selected',
+    'selection_color',
+    'info_color',
+    'info_color_selected',
+    'notification_color',
+    'notification_text_color'
+];
+
+export const ITEM_TEMPLATE_NUMBER_OPTIONS: (keyof ColorConfig)[] = [
+    'selection_opacity'
+];
 
 export enum EVENT {
     MOUSEDOWN = 'mousedown',

--- a/src/custom-sidebar.ts
+++ b/src/custom-sidebar.ts
@@ -30,7 +30,8 @@ import {
     SELECTOR,
     PSEUDO_SELECTOR,
     ATTRIBUTE,
-    CSS_VARIABLES,
+    HA_CSS_VARIABLES,
+    CUSTOM_SIDEBAR_CSS_VARIABLES,
     KEY,
     CLASS,
     EVENT,
@@ -596,25 +597,25 @@ class CustomSidebar {
                 this._configWithExceptions,
                 sidebar,
                 [
-                    ['title_color',             CSS_VARIABLES.CUSTOM_SIDEBAR_TITLE_COLOR],
-                    ['subtitle_color',          CSS_VARIABLES.CUSTOM_SIDEBAR_SUBTITLE_COLOR],
-                    ['sidebar_button_color',    CSS_VARIABLES.CUSTOM_SIDEBAR_BUTTON_COLOR],
-                    ['sidebar_background',      CSS_VARIABLES.CUSTOM_SIDEBAR_BACKGROUND],
-                    ['menu_background',         CSS_VARIABLES.CUSTOM_SIDEBAR_MENU_BACKGROUND],
-                    ['icon_color',              CSS_VARIABLES.CUSTOM_SIDEBAR_ICON_COLOR],
-                    ['icon_color_selected',     CSS_VARIABLES.CUSTOM_SIDEBAR_SELECTED_ICON_COLOR],
-                    ['text_color',              CSS_VARIABLES.CUSTOM_SIDEBAR_TEXT_COLOR],
-                    ['text_color_selected',     CSS_VARIABLES.CUSTOM_SIDEBAR_SELECTED_TEXT_COLOR],
-                    ['selection_color',         CSS_VARIABLES.CUSTOM_SIDEBAR_SELECTION_COLOR],
-                    ['info_color',              CSS_VARIABLES.CUSTOM_SIDEBAR_INFO_COLOR],
-                    ['info_color_selected',     CSS_VARIABLES.CUSTOM_SIDEBAR_SELECTED_INFO_COLOR],
-                    ['notification_color',      CSS_VARIABLES.CUSTOM_SIDEBAR_NOTIFICATION_COLOR],
-                    ['notification_text_color', CSS_VARIABLES.CUSTOM_SIDEBAR_NOTIFICATION_TEXT_COLOR],
-                    ['selection_opacity',       CSS_VARIABLES.CUSTOM_SIDEBAR_SELECTION_OPACITY],
-                    ['divider_color',           CSS_VARIABLES.CUSTOM_SIDEBAR_DIVIDER_COLOR],
-                    ['divider_top_color',       CSS_VARIABLES.CUSTOM_SIDEBAR_DIVIDER_TOP_COLOR],
-                    ['divider_bottom_color',    CSS_VARIABLES.CUSTOM_SIDEBAR_DIVIDER_BOTTOM_COLOR],
-                    ['scrollbar_thumb_color',   CSS_VARIABLES.CUSTOM_SIDEBAR_SCROLLBAR_THUMB_COLOR]
+                    ['title_color',             CUSTOM_SIDEBAR_CSS_VARIABLES.TITLE_COLOR],
+                    ['subtitle_color',          CUSTOM_SIDEBAR_CSS_VARIABLES.SUBTITLE_COLOR],
+                    ['sidebar_button_color',    CUSTOM_SIDEBAR_CSS_VARIABLES.BUTTON_COLOR],
+                    ['sidebar_background',      CUSTOM_SIDEBAR_CSS_VARIABLES.BACKGROUND],
+                    ['menu_background',         CUSTOM_SIDEBAR_CSS_VARIABLES.MENU_BACKGROUND],
+                    ['icon_color',              CUSTOM_SIDEBAR_CSS_VARIABLES.ICON_COLOR],
+                    ['icon_color_selected',     CUSTOM_SIDEBAR_CSS_VARIABLES.SELECTED_ICON_COLOR],
+                    ['text_color',              CUSTOM_SIDEBAR_CSS_VARIABLES.TEXT_COLOR],
+                    ['text_color_selected',     CUSTOM_SIDEBAR_CSS_VARIABLES.SELECTED_TEXT_COLOR],
+                    ['selection_color',         CUSTOM_SIDEBAR_CSS_VARIABLES.SELECTION_COLOR],
+                    ['info_color',              CUSTOM_SIDEBAR_CSS_VARIABLES.INFO_COLOR],
+                    ['info_color_selected',     CUSTOM_SIDEBAR_CSS_VARIABLES.SELECTED_INFO_COLOR],
+                    ['notification_color',      CUSTOM_SIDEBAR_CSS_VARIABLES.NOTIFICATION_COLOR],
+                    ['notification_text_color', CUSTOM_SIDEBAR_CSS_VARIABLES.NOTIFICATION_TEXT_COLOR],
+                    ['selection_opacity',       CUSTOM_SIDEBAR_CSS_VARIABLES.SELECTION_OPACITY],
+                    ['divider_color',           CUSTOM_SIDEBAR_CSS_VARIABLES.DIVIDER_COLOR],
+                    ['divider_top_color',       CUSTOM_SIDEBAR_CSS_VARIABLES.DIVIDER_TOP_COLOR],
+                    ['divider_bottom_color',    CUSTOM_SIDEBAR_CSS_VARIABLES.DIVIDER_BOTTOM_COLOR],
+                    ['scrollbar_thumb_color',   CUSTOM_SIDEBAR_CSS_VARIABLES.SCROLLBAR_THUMB_COLOR]
                 ]
             );
 
@@ -622,7 +623,7 @@ class CustomSidebar {
                 this._configWithExceptions,
                 mcDrawer,
                 [
-                    ['sidebar_border_color',        CSS_VARIABLES.CUSTOM_SIDEBAR_BORDER_COLOR]
+                    ['sidebar_border_color',    CUSTOM_SIDEBAR_CSS_VARIABLES.BORDER_COLOR]
                 ]
             );
 
@@ -660,9 +661,9 @@ class CustomSidebar {
             }, true);
 
             const commonNotificationStyles = `
-                background-color: var(${CSS_VARIABLES.CUSTOM_SIDEBAR_NOTIFICATION_COLOR}, var(--accent-color));
+                background-color: var(${CUSTOM_SIDEBAR_CSS_VARIABLES.NOTIFICATION_COLOR}, var(${ HA_CSS_VARIABLES.ACCENT_COLOR }));
                 border-radius: 20px;
-                color: var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_NOTIFICATION_TEXT_COLOR }, var(${ CSS_VARIABLES.TEXT_ACCENT_COLOR }, var(${ CSS_VARIABLES.TEXT_PRIMARY_COLOR })));
+                color: var(${ CUSTOM_SIDEBAR_CSS_VARIABLES.NOTIFICATION_TEXT_COLOR }, var(${ HA_CSS_VARIABLES.TEXT_ACCENT_COLOR }, var(${ HA_CSS_VARIABLES.TEXT_PRIMARY_COLOR })));
                 font-size: 0.65em;
                 overflow: hidden;
                 padding: 0px 5px;
@@ -673,7 +674,7 @@ class CustomSidebar {
             this._styleManager.addStyle(
                 `
                 ${ SELECTOR.HOST } > ${SELECTOR.MC_DRAWER} {
-                    border-color: var(${CSS_VARIABLES.CUSTOM_SIDEBAR_BORDER_COLOR}, var(${ CSS_VARIABLES.DIVIDER_COLOR }, rgba(0,0,0,.12)));
+                    border-color: var(${CUSTOM_SIDEBAR_CSS_VARIABLES.BORDER_COLOR}, var(${ HA_CSS_VARIABLES.DIVIDER_COLOR }, rgba(0,0,0,.12)));
                 }
                 `,
                 mcDrawer
@@ -682,30 +683,30 @@ class CustomSidebar {
             this._styleManager.addStyle(
                 `
                 ${ SELECTOR.HOST } {
-                    background: var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_BACKGROUND }, var(${ CSS_VARIABLES.SIDEBAR_BACKGROUND_COLOR })) !important;
+                    background: var(${ CUSTOM_SIDEBAR_CSS_VARIABLES.BACKGROUND }, var(${ HA_CSS_VARIABLES.SIDEBAR_BACKGROUND_COLOR })) !important;
                 }
                 ${ SELECTOR.HOST } ${ ELEMENT.PAPER_LISTBOX }${ SELECTOR.HA_SCROLLBAR } {
-                    scrollbar-color: var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_SCROLLBAR_THUMB_COLOR }, var(${ CSS_VARIABLES.SCROLLBAR_THUMB_COLOR })) transparent;
+                    scrollbar-color: var(${ CUSTOM_SIDEBAR_CSS_VARIABLES.SCROLLBAR_THUMB_COLOR }, var(${ HA_CSS_VARIABLES.SCROLLBAR_THUMB_COLOR })) transparent;
                 }
                 ${ SELECTOR.HOST } ${ ELEMENT.PAPER_LISTBOX }${ SELECTOR.HA_SCROLLBAR }${ PSEUDO_SELECTOR.WEBKIT_SCROLLBAR_THUMB } {
-                    background: var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_SCROLLBAR_THUMB_COLOR }, var(${ CSS_VARIABLES.SCROLLBAR_THUMB_COLOR }));
+                    background: var(${ CUSTOM_SIDEBAR_CSS_VARIABLES.SCROLLBAR_THUMB_COLOR }, var(${ HA_CSS_VARIABLES.SCROLLBAR_THUMB_COLOR }));
                 }
                 ${ SELECTOR.HOST } ${ SELECTOR.MENU } {
-                    background: var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_MENU_BACKGROUND }, var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_BACKGROUND }, var(${ CSS_VARIABLES.SIDEBAR_MENU_BUTTON_BACKGROUND_COLOR }, ${ CSS_VARIABLES.PRIMARY_BACKGROUND_COLOR })));
-                    border-bottom: 1px solid var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_DIVIDER_TOP_COLOR }, var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_DIVIDER_COLOR }, var(${ CSS_VARIABLES.DIVIDER_COLOR })));
+                    background: var(${ CUSTOM_SIDEBAR_CSS_VARIABLES.MENU_BACKGROUND }, var(${ CUSTOM_SIDEBAR_CSS_VARIABLES.BACKGROUND }, var(${ HA_CSS_VARIABLES.SIDEBAR_MENU_BUTTON_BACKGROUND_COLOR }, ${ HA_CSS_VARIABLES.PRIMARY_BACKGROUND_COLOR })));
+                    border-bottom: 1px solid var(${ CUSTOM_SIDEBAR_CSS_VARIABLES.DIVIDER_TOP_COLOR }, var(${ CUSTOM_SIDEBAR_CSS_VARIABLES.DIVIDER_COLOR }, var(${ HA_CSS_VARIABLES.DIVIDER_COLOR })));
                 }
                 ${ SELECTOR.MENU }[${ BLOCKED_PROPERTY }] {
                     pointer-events: none;
                 }
                 ${ SELECTOR.HOST } ${ SELECTOR.MENU } > ${ ELEMENT.HA_ICON_BUTTON } {
-                    color: var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_BUTTON_COLOR }, var(${ CSS_VARIABLES.SIDEBAR_ICON_COLOR }));
+                    color: var(${ CUSTOM_SIDEBAR_CSS_VARIABLES.BUTTON_COLOR }, var(${ HA_CSS_VARIABLES.SIDEBAR_ICON_COLOR }));
                 }
                 ${ SELECTOR.HOST } ${ SELECTOR.MENU } > ${ SELECTOR.TITLE } {
-                    color: var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_TITLE_COLOR }, var(${ CSS_VARIABLES.SIDEBAR_TITLE_COLOR }, var(${ CSS_VARIABLES.PRIMARY_TEXT_COLOR })));
+                    color: var(${ CUSTOM_SIDEBAR_CSS_VARIABLES.TITLE_COLOR }, var(${ HA_CSS_VARIABLES.SIDEBAR_TITLE_COLOR }, var(${ HA_CSS_VARIABLES.PRIMARY_TEXT_COLOR })));
                 }  
                 ${ SELECTOR.HOST } ${ SELECTOR.MENU } > ${ SELECTOR.TITLE }${ PSEUDO_SELECTOR.AFTER } {
                     content: attr(data-subtitle);
-                    color: var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_SUBTITLE_COLOR }, var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_TITLE_COLOR }, var(${ CSS_VARIABLES.SIDEBAR_TITLE_COLOR }, var(${ CSS_VARIABLES.PRIMARY_TEXT_COLOR }))));
+                    color: var(${ CUSTOM_SIDEBAR_CSS_VARIABLES.SUBTITLE_COLOR }, var(${ CUSTOM_SIDEBAR_CSS_VARIABLES.TITLE_COLOR }, var(${ HA_CSS_VARIABLES.SIDEBAR_TITLE_COLOR }, var(${ HA_CSS_VARIABLES.PRIMARY_TEXT_COLOR }))));
                     display: block;
                     font-size: 12px;
                     line-height: 1.5;
@@ -714,23 +715,23 @@ class CustomSidebar {
                     pointer-events: all;
                 }
                 ${ SELECTOR.HOST } ${ SELECTOR.ITEM } > ${ ELEMENT.PAPER_ICON_ITEM }${ PSEUDO_SELECTOR.BEFORE } {
-                    background-color: var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_SELECTION_COLOR }, var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_SELECTED_ICON_COLOR }, var(${ CSS_VARIABLES.SIDEBAR_SELECTED_ICON_COLOR })));
-                    opacity: var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_SELECTION_OPACITY }, 0.12);
+                    background-color: var(${ CUSTOM_SIDEBAR_CSS_VARIABLES.SELECTION_COLOR }, var(${ CUSTOM_SIDEBAR_CSS_VARIABLES.SELECTED_ICON_COLOR }, var(${ HA_CSS_VARIABLES.SIDEBAR_SELECTED_ICON_COLOR })));
+                    opacity: var(${ CUSTOM_SIDEBAR_CSS_VARIABLES.SELECTION_OPACITY }, 0.12);
                 }
                 ${ SELECTOR.HOST } ${ SELECTOR.ITEM }[${ ATTRIBUTE.WITH_NOTIFICATION }] > ${ ELEMENT.PAPER_ICON_ITEM } > ${ SELECTOR.ITEM_TEXT } {
                     max-width: calc(100% - 100px);
                 }
                 ${ SELECTOR.HOST } ${ SELECTOR.ITEM_SELECTED } > ${ ELEMENT.PAPER_ICON_ITEM } > :is(${ ELEMENT.HA_SVG_ICON }, ${ ELEMENT.HA_ICON }) {
-                    color: var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_SELECTED_ICON_COLOR }, var(${ CSS_VARIABLES.SIDEBAR_SELECTED_ICON_COLOR }));
+                    color: var(${ CUSTOM_SIDEBAR_CSS_VARIABLES.SELECTED_ICON_COLOR }, var(${ HA_CSS_VARIABLES.SIDEBAR_SELECTED_ICON_COLOR }));
                 }
                 ${ SELECTOR.HOST } ${ SELECTOR.ITEM_SELECTED } > ${ ELEMENT.PAPER_ICON_ITEM } > ${ SELECTOR.ITEM_TEXT } {
-                    color: var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_SELECTED_TEXT_COLOR }, var(${ CSS_VARIABLES.SIDEBAR_SELECTED_TEXT_COLOR }));
+                    color: var(${ CUSTOM_SIDEBAR_CSS_VARIABLES.SELECTED_TEXT_COLOR }, var(${ HA_CSS_VARIABLES.SIDEBAR_SELECTED_TEXT_COLOR }));
                 }
                 ${ SELECTOR.HOST } ${ ELEMENT.PAPER_ICON_ITEM } > :is(${ ELEMENT.HA_SVG_ICON }, ${ ELEMENT.HA_ICON }) {
-                    color: var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_ICON_COLOR }, var(${ CSS_VARIABLES.SIDEBAR_ICON_COLOR }));
+                    color: var(${ CUSTOM_SIDEBAR_CSS_VARIABLES.ICON_COLOR }, var(${ HA_CSS_VARIABLES.SIDEBAR_ICON_COLOR }));
                 }
                 ${ SELECTOR.HOST } ${ ELEMENT.PAPER_ICON_ITEM } > ${ SELECTOR.ITEM_TEXT } {
-                    color: var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_TEXT_COLOR }, var(${ CSS_VARIABLES.SIDEBAR_TEXT_COLOR }));
+                    color: var(${ CUSTOM_SIDEBAR_CSS_VARIABLES.TEXT_COLOR }, var(${ HA_CSS_VARIABLES.SIDEBAR_TEXT_COLOR }));
                 }
                 ${ SELECTOR.HOST } ${ ELEMENT.PAPER_ICON_ITEM } > ${ SELECTOR.NOTIFICATION_BADGE }:not(${ SELECTOR.NOTIFICATIONS_BADGE_COLLAPSED }) {
                     left: calc(var(--app-drawer-width, 248px) - 22px);
@@ -745,11 +746,11 @@ class CustomSidebar {
                     ${commonNotificationStyles}
                 }
                 ${ SELECTOR.HOST } ${ ELEMENT.PAPER_ICON_ITEM } > ${ SELECTOR.CONFIGURATION_BADGE } {
-                    background-color: var(${CSS_VARIABLES.CUSTOM_SIDEBAR_NOTIFICATION_COLOR}, var(--accent-color));
-                    color: var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_NOTIFICATION_TEXT_COLOR }, var(${ CSS_VARIABLES.TEXT_ACCENT_COLOR }, var(${ CSS_VARIABLES.TEXT_PRIMARY_COLOR })));
+                    background-color: var(${CUSTOM_SIDEBAR_CSS_VARIABLES.NOTIFICATION_COLOR}, var(${ HA_CSS_VARIABLES.ACCENT_COLOR }));
+                    color: var(${ CUSTOM_SIDEBAR_CSS_VARIABLES.NOTIFICATION_TEXT_COLOR }, var(${ HA_CSS_VARIABLES.TEXT_ACCENT_COLOR }, var(${ HA_CSS_VARIABLES.TEXT_PRIMARY_COLOR })));
                 }
                 ${ SELECTOR.HOST } ${ SELECTOR.DIVIDER }${ PSEUDO_SELECTOR.BEFORE } {
-                    background-color: var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_DIVIDER_BOTTOM_COLOR }, var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_DIVIDER_COLOR }, var(${ CSS_VARIABLES.DIVIDER_COLOR })));
+                    background-color: var(${ CUSTOM_SIDEBAR_CSS_VARIABLES.DIVIDER_BOTTOM_COLOR }, var(${ CUSTOM_SIDEBAR_CSS_VARIABLES.DIVIDER_COLOR }, var(${ HA_CSS_VARIABLES.DIVIDER_COLOR })));
                 }
                 ${ SELECTOR.HOST_EXPANDED } ${ ELEMENT.PAPER_LISTBOX } > ${ SELECTOR.ITEM } > ${ ELEMENT.PAPER_ICON_ITEM } > ${ SELECTOR.NOTIFICATIONS_BADGE_COLLAPSED } {
                     opacity: 0;
@@ -770,14 +771,14 @@ class CustomSidebar {
                     white-space: nowrap;
                 }
                 ${ SELECTOR.HOST_EXPANDED } ${ ELEMENT.PAPER_LISTBOX } > ${ SELECTOR.ITEM } > ${ ELEMENT.PAPER_ICON_ITEM } > ${ SELECTOR.ITEM_TEXT }${ SELECTOR.DATA_INFO }${ PSEUDO_SELECTOR.AFTER } {
-                    color: var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_INFO_COLOR }, var(${ CSS_VARIABLES.SIDEBAR_TEXT_COLOR }));
+                    color: var(${ CUSTOM_SIDEBAR_CSS_VARIABLES.INFO_COLOR }, var(${ HA_CSS_VARIABLES.SIDEBAR_TEXT_COLOR }));
                     display: block;
                 }
                 ${ SELECTOR.HOST_EXPANDED } ${ ELEMENT.PAPER_LISTBOX } > ${ SELECTOR.ITEM }${ SELECTOR.ITEM_SELECTED } > ${ ELEMENT.PAPER_ICON_ITEM } > ${ SELECTOR.ITEM_TEXT } {
                     z-index: 1;
                 }
                 ${ SELECTOR.HOST_EXPANDED } ${ ELEMENT.PAPER_LISTBOX } > ${ SELECTOR.ITEM }${ SELECTOR.ITEM_SELECTED } > ${ ELEMENT.PAPER_ICON_ITEM } > ${ SELECTOR.ITEM_TEXT }${ SELECTOR.DATA_INFO }${ PSEUDO_SELECTOR.AFTER } {
-                    color: var(${ CSS_VARIABLES.CUSTOM_SIDEBAR_SELECTED_INFO_COLOR }, var(${ CSS_VARIABLES.SIDEBAR_SELECTED_TEXT_COLOR }));
+                    color: var(${ CUSTOM_SIDEBAR_CSS_VARIABLES.SELECTED_INFO_COLOR }, var(${ HA_CSS_VARIABLES.SIDEBAR_SELECTED_TEXT_COLOR }));
                 }
                 ${ this._configWithExceptions.styles || '' }
                 `.trim(),
@@ -934,16 +935,16 @@ class CustomSidebar {
                             orderItem,
                             orderItem.element,
                             [
-                                ['icon_color',              CSS_VARIABLES.CUSTOM_SIDEBAR_ICON_COLOR],
-                                ['icon_color_selected',     CSS_VARIABLES.CUSTOM_SIDEBAR_SELECTED_ICON_COLOR],
-                                ['text_color',              CSS_VARIABLES.CUSTOM_SIDEBAR_TEXT_COLOR],
-                                ['text_color_selected',     CSS_VARIABLES.CUSTOM_SIDEBAR_SELECTED_TEXT_COLOR],
-                                ['selection_color',         CSS_VARIABLES.CUSTOM_SIDEBAR_SELECTION_COLOR],
-                                ['selection_opacity',       CSS_VARIABLES.CUSTOM_SIDEBAR_SELECTION_OPACITY],
-                                ['info_color',              CSS_VARIABLES.CUSTOM_SIDEBAR_INFO_COLOR],
-                                ['info_color_selected',     CSS_VARIABLES.CUSTOM_SIDEBAR_SELECTED_INFO_COLOR],
-                                ['notification_color',      CSS_VARIABLES.CUSTOM_SIDEBAR_NOTIFICATION_COLOR],
-                                ['notification_text_color', CSS_VARIABLES.CUSTOM_SIDEBAR_NOTIFICATION_TEXT_COLOR]
+                                ['icon_color',              CUSTOM_SIDEBAR_CSS_VARIABLES.ICON_COLOR],
+                                ['icon_color_selected',     CUSTOM_SIDEBAR_CSS_VARIABLES.SELECTED_ICON_COLOR],
+                                ['text_color',              CUSTOM_SIDEBAR_CSS_VARIABLES.TEXT_COLOR],
+                                ['text_color_selected',     CUSTOM_SIDEBAR_CSS_VARIABLES.SELECTED_TEXT_COLOR],
+                                ['selection_color',         CUSTOM_SIDEBAR_CSS_VARIABLES.SELECTION_COLOR],
+                                ['selection_opacity',       CUSTOM_SIDEBAR_CSS_VARIABLES.SELECTION_OPACITY],
+                                ['info_color',              CUSTOM_SIDEBAR_CSS_VARIABLES.INFO_COLOR],
+                                ['info_color_selected',     CUSTOM_SIDEBAR_CSS_VARIABLES.SELECTED_INFO_COLOR],
+                                ['notification_color',      CUSTOM_SIDEBAR_CSS_VARIABLES.NOTIFICATION_COLOR],
+                                ['notification_text_color', CUSTOM_SIDEBAR_CSS_VARIABLES.NOTIFICATION_TEXT_COLOR]
                             ]
                         );
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -52,7 +52,7 @@ export enum Match {
     HREF = 'href'
 }
 
-interface ColorConfig {
+export interface ColorConfig {
     icon_color?: string;
     icon_color_selected?: string;
     text_color?: string;

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -6,26 +6,19 @@ import {
 import {
     NAMESPACE,
     TYPE,
+    ITEM_TEMPLATE_STRING_OPTIONS,
+    ITEM_TEMPLATE_NUMBER_OPTIONS,
     FLUSH_PROMISE_DELAY,
     PARTIAL_REGEXP
 } from '@constants';
 import { version } from '../../package.json';
 
-const EXTENDABLE_ITEM_OPTIONS = [
-    'icon_color',
-    'icon_color_selected',
-    'text_color',
-    'text_color_selected',
-    'selection_color',
-    'selection_opacity',
-    'info_color',
-    'info_color_selected',
-    'notification_color',
-    'notification_text_color'
-] as const;
+const ITEM_TEMPLATE_OPTIONS = [
+    ...ITEM_TEMPLATE_STRING_OPTIONS,
+    ...ITEM_TEMPLATE_NUMBER_OPTIONS
+];
 
 const EXTENDABLE_OPTIONS = [
-    ...EXTENDABLE_ITEM_OPTIONS,
     'title',
     'subtitle',
     'sidebar_editable',
@@ -40,7 +33,8 @@ const EXTENDABLE_OPTIONS = [
     'divider_top_color',
     'divider_bottom_color',
     'scrollbar_thumb_color',
-    'styles'
+    'styles',
+    ...ITEM_TEMPLATE_OPTIONS
 ] as const;
 
 const ONLY_CONFIG_OPTIONS = [
@@ -49,7 +43,7 @@ const ONLY_CONFIG_OPTIONS = [
     'partials'
 ] as const;
 
-type ExtendableItemConfigOption = typeof EXTENDABLE_ITEM_OPTIONS[number];
+type ExtendableItemConfigOption = typeof ITEM_TEMPLATE_OPTIONS[number];
 type ExtendableConfigOption = typeof EXTENDABLE_OPTIONS[number];
 type OnlyConfigOption = typeof ONLY_CONFIG_OPTIONS[number];
 type OptionsFromBase = Record<string, Config[ExtendableConfigOption | OnlyConfigOption]>;
@@ -98,7 +92,7 @@ const flatConfigOrder = (order: ConfigOrder[], config: Config): ConfigOrder[] =>
     });
 
     orderMap.forEach((orderItem: ConfigOrder): void => {
-        EXTENDABLE_ITEM_OPTIONS.forEach((option: ExtendableItemConfigOption): void => {
+        ITEM_TEMPLATE_OPTIONS.forEach((option: ExtendableItemConfigOption): void => {
             if (
                 orderItem[option] === undefined &&
                 config[option] !== undefined

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -8,6 +8,8 @@ import {
     TYPE,
     OBJECT_TO_STRING,
     SIDEBAR_MODE_TO_DOCKED_SIDEBAR,
+    ITEM_TEMPLATE_STRING_OPTIONS,
+    ITEM_TEMPLATE_NUMBER_OPTIONS,
     JS_TEMPLATE_REG,
     JINJA_TEMPLATE_REG
 } from '@constants';
@@ -17,15 +19,6 @@ const ERROR_PREFIX = 'Invalid configuration';
 const BASE_CONFIG_OPTIONS = [
     'title',
     'subtitle',
-    'icon_color',
-    'icon_color_selected',
-    'text_color',
-    'text_color_selected',
-    'selection_color',
-    'info_color',
-    'info_color_selected',
-    'notification_color',
-    'notification_text_color',
     'sidebar_background',
     'title_color',
     'subtitle_color',
@@ -36,7 +29,8 @@ const BASE_CONFIG_OPTIONS = [
     'divider_top_color',
     'divider_bottom_color',
     'scrollbar_thumb_color',
-    'styles'
+    'styles',
+    ...ITEM_TEMPLATE_STRING_OPTIONS
 ] as const;
 
 const validateStringOptions = <T, K extends keyof T>(obj: T, props: K[], prefix: string): void => {
@@ -46,6 +40,18 @@ const validateStringOptions = <T, K extends keyof T>(obj: T, props: K[], prefix:
             typeof obj[prop] !== TYPE.STRING
         ) {
             throw new SyntaxError(`${prefix} "${String(prop)}" property should be a string`);
+        }
+    });
+};
+
+const validateStringOrNumberOptions = <T, K extends keyof T>(obj: T, props: K[], prefix: string): void => {
+    props.forEach((prop: K): void => {
+        if (
+            typeof obj[prop] !== TYPE.UNDEFINED &&
+            typeof obj[prop] !== TYPE.STRING &&
+            typeof obj[prop] !== TYPE.NUMBER
+        ) {
+            throw new SyntaxError(`${prefix} "${String(prop)}" property should be a number or a string`);
         }
     });
 };
@@ -107,6 +113,14 @@ const validateExceptionItem = (exception: ConfigException): void => {
         `${ERROR_PREFIX}, exceptions`
     );
 
+    validateStringOrNumberOptions(
+        exception,
+        [
+            ...ITEM_TEMPLATE_NUMBER_OPTIONS
+        ],
+        `${ERROR_PREFIX}, exceptions`
+    );
+
     validateStringOrArrayOfStringsOptions(
         [
             ['user', exception.user],
@@ -137,14 +151,6 @@ const validateExceptionItem = (exception: ConfigException): void => {
         !(exception.sidebar_mode in SIDEBAR_MODE_TO_DOCKED_SIDEBAR)
     ) {
         throw new SyntaxError(`${ERROR_PREFIX}, exceptions "sidebar_mode" property should be ${SidebarMode.HIDDEN}, ${SidebarMode.NARROW} or ${SidebarMode.EXTENDED}`);
-    }
-
-    if (
-        typeof exception.selection_opacity !== TYPE.UNDEFINED &&
-        typeof exception.selection_opacity !== TYPE.NUMBER &&
-        typeof exception.selection_opacity !== TYPE.STRING
-    ) {
-        throw new SyntaxError(`${ERROR_PREFIX}, exceptions "selection_opacity" property should be a number or a template string`);
     }
 
     if (
@@ -185,26 +191,18 @@ const validateConfigItem = (configItem: ConfigItem): void => {
         [
             'item',
             'info',
-            'icon_color',
-            'icon_color_selected',
-            'text_color',
-            'text_color_selected',
-            'selection_color',
-            'info_color',
-            'info_color_selected',
-            'notification_color',
-            'notification_text_color'
+            ...ITEM_TEMPLATE_STRING_OPTIONS
         ],
         `${ERROR_PREFIX} in ${configItem.item},`
     );
 
-    if (
-        typeof configItem.selection_opacity !== TYPE.UNDEFINED &&
-        typeof configItem.selection_opacity !== TYPE.NUMBER &&
-        typeof configItem.selection_opacity !== TYPE.STRING
-    ) {
-        throw new SyntaxError(`${ERROR_PREFIX} in ${configItem.item}, "selection_opacity" property should be a number or a template string`);
-    }
+    validateStringOrNumberOptions(
+        configItem,
+        [
+            ...ITEM_TEMPLATE_NUMBER_OPTIONS
+        ],
+        `${ERROR_PREFIX} in ${configItem.item},`
+    );
 
     if (configItem.new_item) {
         validateStringOptions(
@@ -229,13 +227,13 @@ export const validateConfig = (config: Config): void => {
         ],
         `${ERROR_PREFIX},`
     );
-    if (
-        typeof config.selection_opacity !== TYPE.UNDEFINED &&
-        typeof config.selection_opacity !== TYPE.NUMBER &&
-        typeof config.selection_opacity !== TYPE.STRING
-    ) {
-        throw new SyntaxError(`${ERROR_PREFIX}, "selection_opacity" property should be a number or a template string`);
-    }
+    validateStringOrNumberOptions(
+        config,
+        [
+            ...ITEM_TEMPLATE_NUMBER_OPTIONS
+        ],
+        `${ERROR_PREFIX},`
+    );
     if (
         typeof config.sidebar_editable !== TYPE.UNDEFINED &&
         typeof config.sidebar_editable !== TYPE.BOOLEAN &&

--- a/tests/13 - validator-errors.spec.ts
+++ b/tests/13 - validator-errors.spec.ts
@@ -113,7 +113,7 @@ test.describe('main options', () => {
             json: {
                 selection_opacity: [100]
             },
-            error: `${ERROR_PREFIX}, "selection_opacity" property should be a number or a template string`
+            error: `${ERROR_PREFIX}, "selection_opacity" property should be a number or a string`
         },
         {
             title: 'should throw an error if it has a malformed styles option',
@@ -362,7 +362,7 @@ test.describe('order item property', () => {
                     }
                 ]
             },
-            error: `${ERROR_PREFIX} in config, "selection_opacity" property should be a number or a template string`
+            error: `${ERROR_PREFIX} in config, "selection_opacity" property should be a number or a string`
         },
         {
             title: 'should throw an error if the "icon" property of a new icon is not a string',
@@ -449,7 +449,7 @@ test.describe('exceptions', () => {
                     }
                 ]
             },
-            error: `${ERROR_PREFIX}, exceptions "selection_opacity" property should be a number or a template string`
+            error: `${ERROR_PREFIX}, exceptions "selection_opacity" property should be a number or a string`
         },
         {
             title: 'should throw an error if it has an invalid "styles" option',


### PR DESCRIPTION
This pull request refactors the way in which the CSS variables are managed. As there are tons of variables at the moment, two enums have been created to hold separately `custom-sidebar` and Home Assistant CSS variables. Also, a common enum has been created to be used for the validations and the extending/overriding options functionality, to reduce the risk of committing a mistake and not including an option in some places when it is introduced.