### PR TITLE
Avoid code repetition creating options variables map constants

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,5 +1,6 @@
 import{
-    ColorConfig,
+    ItemColorConfig,
+    SidebarColorConfig,
     SidebarMode,
     DockedSidebar
 } from '@types';
@@ -93,16 +94,42 @@ export enum CUSTOM_SIDEBAR_CSS_VARIABLES {
     SCROLLBAR_THUMB_COLOR = '--custom-sidebar-scrollbar-thumb-color',
 
     ICON_COLOR = '--custom-sidebar-icon-color',
+    ICON_COLOR_SELECTED = '--custom-sidebar-icon-color-selected',
     TEXT_COLOR = '--custom-sidebar-text-color',
-    SELECTED_TEXT_COLOR = '--custom-sidebar-selected-text-color',
-    SELECTED_ICON_COLOR = '--custom-sidebar-selected-icon-color',
+    TEXT_COLOR_SELECTED = '--custom-sidebar-text-color-selected',
     SELECTION_COLOR = '--custom-sidebar-selection-color',
     SELECTION_OPACITY = '--custom-sidebar-selection-opacity',
     INFO_COLOR = '--custom-sidebar-info-color',
-    SELECTED_INFO_COLOR = '--custom-sidebar-selected-info-color',
+    INFO_COLOR_SELECTED = '--custom-sidebar-info-color-selected',
     NOTIFICATION_COLOR = '--custom-sidebar-notification-color',
     NOTIFICATION_TEXT_COLOR = '--custom-sidebar-notification-text-color'
 }
+
+export const ITEM_OPTIONS_VARIABLES_MAP: [keyof ItemColorConfig, string][] = [
+    ['icon_color',                    CUSTOM_SIDEBAR_CSS_VARIABLES.ICON_COLOR],
+    ['icon_color_selected',           CUSTOM_SIDEBAR_CSS_VARIABLES.ICON_COLOR_SELECTED],
+    ['text_color',                    CUSTOM_SIDEBAR_CSS_VARIABLES.TEXT_COLOR],
+    ['text_color_selected',           CUSTOM_SIDEBAR_CSS_VARIABLES.TEXT_COLOR_SELECTED],
+    ['selection_color',               CUSTOM_SIDEBAR_CSS_VARIABLES.SELECTION_COLOR],
+    ['selection_opacity',             CUSTOM_SIDEBAR_CSS_VARIABLES.SELECTION_OPACITY],
+    ['info_color',                    CUSTOM_SIDEBAR_CSS_VARIABLES.INFO_COLOR],
+    ['info_color_selected',           CUSTOM_SIDEBAR_CSS_VARIABLES.INFO_COLOR_SELECTED],
+    ['notification_color',            CUSTOM_SIDEBAR_CSS_VARIABLES.NOTIFICATION_COLOR],
+    ['notification_text_color',       CUSTOM_SIDEBAR_CSS_VARIABLES.NOTIFICATION_TEXT_COLOR]
+];
+
+export const SIDEBAR_OPTIONS_VARIABLES_MAP: [keyof SidebarColorConfig, string][] = [
+    ['title_color',                   CUSTOM_SIDEBAR_CSS_VARIABLES.TITLE_COLOR],
+    ['subtitle_color',                CUSTOM_SIDEBAR_CSS_VARIABLES.SUBTITLE_COLOR],
+    ['sidebar_button_color',          CUSTOM_SIDEBAR_CSS_VARIABLES.BUTTON_COLOR],
+    ['sidebar_background',            CUSTOM_SIDEBAR_CSS_VARIABLES.BACKGROUND],
+    ['menu_background',               CUSTOM_SIDEBAR_CSS_VARIABLES.MENU_BACKGROUND],
+    ['scrollbar_thumb_color',         CUSTOM_SIDEBAR_CSS_VARIABLES.SCROLLBAR_THUMB_COLOR],
+    ['divider_color',                 CUSTOM_SIDEBAR_CSS_VARIABLES.DIVIDER_COLOR],
+    ['divider_top_color',             CUSTOM_SIDEBAR_CSS_VARIABLES.DIVIDER_TOP_COLOR],
+    ['divider_bottom_color',          CUSTOM_SIDEBAR_CSS_VARIABLES.DIVIDER_BOTTOM_COLOR],
+    ...ITEM_OPTIONS_VARIABLES_MAP
+];
 
 export enum CLASS {
     NOTIFICATIONS_BADGE = 'notification-badge',
@@ -122,7 +149,7 @@ export enum ATTRIBUTE {
     STYLE = 'style'
 }
 
-export const ITEM_TEMPLATE_STRING_OPTIONS: (keyof ColorConfig)[] = [
+export const ITEM_TEMPLATE_STRING_OPTIONS: (keyof ItemColorConfig)[] = [
     'icon_color',
     'icon_color_selected',
     'text_color',
@@ -134,7 +161,7 @@ export const ITEM_TEMPLATE_STRING_OPTIONS: (keyof ColorConfig)[] = [
     'notification_text_color'
 ];
 
-export const ITEM_TEMPLATE_NUMBER_OPTIONS: (keyof ColorConfig)[] = [
+export const ITEM_TEMPLATE_NUMBER_OPTIONS: (keyof ItemColorConfig)[] = [
     'selection_opacity'
 ];
 

--- a/src/custom-sidebar.ts
+++ b/src/custom-sidebar.ts
@@ -32,6 +32,8 @@ import {
     ATTRIBUTE,
     HA_CSS_VARIABLES,
     CUSTOM_SIDEBAR_CSS_VARIABLES,
+    ITEM_OPTIONS_VARIABLES_MAP,
+    SIDEBAR_OPTIONS_VARIABLES_MAP,
     KEY,
     CLASS,
     EVENT,
@@ -596,27 +598,7 @@ class CustomSidebar {
             this._subscribeTemplateColorChanges(
                 this._configWithExceptions,
                 sidebar,
-                [
-                    ['title_color',             CUSTOM_SIDEBAR_CSS_VARIABLES.TITLE_COLOR],
-                    ['subtitle_color',          CUSTOM_SIDEBAR_CSS_VARIABLES.SUBTITLE_COLOR],
-                    ['sidebar_button_color',    CUSTOM_SIDEBAR_CSS_VARIABLES.BUTTON_COLOR],
-                    ['sidebar_background',      CUSTOM_SIDEBAR_CSS_VARIABLES.BACKGROUND],
-                    ['menu_background',         CUSTOM_SIDEBAR_CSS_VARIABLES.MENU_BACKGROUND],
-                    ['icon_color',              CUSTOM_SIDEBAR_CSS_VARIABLES.ICON_COLOR],
-                    ['icon_color_selected',     CUSTOM_SIDEBAR_CSS_VARIABLES.SELECTED_ICON_COLOR],
-                    ['text_color',              CUSTOM_SIDEBAR_CSS_VARIABLES.TEXT_COLOR],
-                    ['text_color_selected',     CUSTOM_SIDEBAR_CSS_VARIABLES.SELECTED_TEXT_COLOR],
-                    ['selection_color',         CUSTOM_SIDEBAR_CSS_VARIABLES.SELECTION_COLOR],
-                    ['info_color',              CUSTOM_SIDEBAR_CSS_VARIABLES.INFO_COLOR],
-                    ['info_color_selected',     CUSTOM_SIDEBAR_CSS_VARIABLES.SELECTED_INFO_COLOR],
-                    ['notification_color',      CUSTOM_SIDEBAR_CSS_VARIABLES.NOTIFICATION_COLOR],
-                    ['notification_text_color', CUSTOM_SIDEBAR_CSS_VARIABLES.NOTIFICATION_TEXT_COLOR],
-                    ['selection_opacity',       CUSTOM_SIDEBAR_CSS_VARIABLES.SELECTION_OPACITY],
-                    ['divider_color',           CUSTOM_SIDEBAR_CSS_VARIABLES.DIVIDER_COLOR],
-                    ['divider_top_color',       CUSTOM_SIDEBAR_CSS_VARIABLES.DIVIDER_TOP_COLOR],
-                    ['divider_bottom_color',    CUSTOM_SIDEBAR_CSS_VARIABLES.DIVIDER_BOTTOM_COLOR],
-                    ['scrollbar_thumb_color',   CUSTOM_SIDEBAR_CSS_VARIABLES.SCROLLBAR_THUMB_COLOR]
-                ]
+                SIDEBAR_OPTIONS_VARIABLES_MAP
             );
 
             this._subscribeTemplateColorChanges(
@@ -715,17 +697,17 @@ class CustomSidebar {
                     pointer-events: all;
                 }
                 ${ SELECTOR.HOST } ${ SELECTOR.ITEM } > ${ ELEMENT.PAPER_ICON_ITEM }${ PSEUDO_SELECTOR.BEFORE } {
-                    background-color: var(${ CUSTOM_SIDEBAR_CSS_VARIABLES.SELECTION_COLOR }, var(${ CUSTOM_SIDEBAR_CSS_VARIABLES.SELECTED_ICON_COLOR }, var(${ HA_CSS_VARIABLES.SIDEBAR_SELECTED_ICON_COLOR })));
+                    background-color: var(${ CUSTOM_SIDEBAR_CSS_VARIABLES.SELECTION_COLOR }, var(${ CUSTOM_SIDEBAR_CSS_VARIABLES.ICON_COLOR_SELECTED }, var(${ HA_CSS_VARIABLES.SIDEBAR_SELECTED_ICON_COLOR })));
                     opacity: var(${ CUSTOM_SIDEBAR_CSS_VARIABLES.SELECTION_OPACITY }, 0.12);
                 }
                 ${ SELECTOR.HOST } ${ SELECTOR.ITEM }[${ ATTRIBUTE.WITH_NOTIFICATION }] > ${ ELEMENT.PAPER_ICON_ITEM } > ${ SELECTOR.ITEM_TEXT } {
                     max-width: calc(100% - 100px);
                 }
                 ${ SELECTOR.HOST } ${ SELECTOR.ITEM_SELECTED } > ${ ELEMENT.PAPER_ICON_ITEM } > :is(${ ELEMENT.HA_SVG_ICON }, ${ ELEMENT.HA_ICON }) {
-                    color: var(${ CUSTOM_SIDEBAR_CSS_VARIABLES.SELECTED_ICON_COLOR }, var(${ HA_CSS_VARIABLES.SIDEBAR_SELECTED_ICON_COLOR }));
+                    color: var(${ CUSTOM_SIDEBAR_CSS_VARIABLES.ICON_COLOR_SELECTED }, var(${ HA_CSS_VARIABLES.SIDEBAR_SELECTED_ICON_COLOR }));
                 }
                 ${ SELECTOR.HOST } ${ SELECTOR.ITEM_SELECTED } > ${ ELEMENT.PAPER_ICON_ITEM } > ${ SELECTOR.ITEM_TEXT } {
-                    color: var(${ CUSTOM_SIDEBAR_CSS_VARIABLES.SELECTED_TEXT_COLOR }, var(${ HA_CSS_VARIABLES.SIDEBAR_SELECTED_TEXT_COLOR }));
+                    color: var(${ CUSTOM_SIDEBAR_CSS_VARIABLES.TEXT_COLOR_SELECTED }, var(${ HA_CSS_VARIABLES.SIDEBAR_SELECTED_TEXT_COLOR }));
                 }
                 ${ SELECTOR.HOST } ${ ELEMENT.PAPER_ICON_ITEM } > :is(${ ELEMENT.HA_SVG_ICON }, ${ ELEMENT.HA_ICON }) {
                     color: var(${ CUSTOM_SIDEBAR_CSS_VARIABLES.ICON_COLOR }, var(${ HA_CSS_VARIABLES.SIDEBAR_ICON_COLOR }));
@@ -778,7 +760,7 @@ class CustomSidebar {
                     z-index: 1;
                 }
                 ${ SELECTOR.HOST_EXPANDED } ${ ELEMENT.PAPER_LISTBOX } > ${ SELECTOR.ITEM }${ SELECTOR.ITEM_SELECTED } > ${ ELEMENT.PAPER_ICON_ITEM } > ${ SELECTOR.ITEM_TEXT }${ SELECTOR.DATA_INFO }${ PSEUDO_SELECTOR.AFTER } {
-                    color: var(${ CUSTOM_SIDEBAR_CSS_VARIABLES.SELECTED_INFO_COLOR }, var(${ HA_CSS_VARIABLES.SIDEBAR_SELECTED_TEXT_COLOR }));
+                    color: var(${ CUSTOM_SIDEBAR_CSS_VARIABLES.INFO_COLOR_SELECTED }, var(${ HA_CSS_VARIABLES.SIDEBAR_SELECTED_TEXT_COLOR }));
                 }
                 ${ this._configWithExceptions.styles || '' }
                 `.trim(),
@@ -934,18 +916,7 @@ class CustomSidebar {
                         this._subscribeTemplateColorChanges(
                             orderItem,
                             orderItem.element,
-                            [
-                                ['icon_color',              CUSTOM_SIDEBAR_CSS_VARIABLES.ICON_COLOR],
-                                ['icon_color_selected',     CUSTOM_SIDEBAR_CSS_VARIABLES.SELECTED_ICON_COLOR],
-                                ['text_color',              CUSTOM_SIDEBAR_CSS_VARIABLES.TEXT_COLOR],
-                                ['text_color_selected',     CUSTOM_SIDEBAR_CSS_VARIABLES.SELECTED_TEXT_COLOR],
-                                ['selection_color',         CUSTOM_SIDEBAR_CSS_VARIABLES.SELECTION_COLOR],
-                                ['selection_opacity',       CUSTOM_SIDEBAR_CSS_VARIABLES.SELECTION_OPACITY],
-                                ['info_color',              CUSTOM_SIDEBAR_CSS_VARIABLES.INFO_COLOR],
-                                ['info_color_selected',     CUSTOM_SIDEBAR_CSS_VARIABLES.SELECTED_INFO_COLOR],
-                                ['notification_color',      CUSTOM_SIDEBAR_CSS_VARIABLES.NOTIFICATION_COLOR],
-                                ['notification_text_color', CUSTOM_SIDEBAR_CSS_VARIABLES.NOTIFICATION_TEXT_COLOR]
-                            ]
+                            ITEM_OPTIONS_VARIABLES_MAP
                         );
 
                         if (orderItem.new_item) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -52,7 +52,7 @@ export enum Match {
     HREF = 'href'
 }
 
-export interface ColorConfig {
+export interface ItemColorConfig {
     icon_color?: string;
     icon_color_selected?: string;
     text_color?: string;
@@ -65,7 +65,20 @@ export interface ColorConfig {
     notification_text_color?: string;
 }
 
-export interface ConfigItem extends ColorConfig {
+export interface SidebarColorConfig extends ItemColorConfig {
+    title_color?: string;
+    subtitle_color?: string;
+    sidebar_button_color?: string;
+    sidebar_background?: string;
+    menu_background?: string;
+    scrollbar_thumb_color?: string;
+    divider_color?: string;
+    divider_top_color?: string;
+    divider_bottom_color?: string;
+    sidebar_border_color?: string;
+}
+
+export interface ConfigItem extends ItemColorConfig {
     item: string;
     match?: `${Match}`;
     exact?: boolean;
@@ -91,22 +104,12 @@ export interface ConfigNewItem extends Omit<ConfigItem, 'new_item'> {
 export type ConfigOrder = ConfigItem | ConfigNewItem;
 export type ConfigOrderWithItem = ConfigOrder & { element?: HTMLAnchorElement };
 
-interface BaseConfig extends ColorConfig {
+interface BaseConfig extends SidebarColorConfig {
     title?: string;
     subtitle?: string;
     order?: ConfigOrder[];
     sidebar_editable?: boolean | string;
     sidebar_mode?: `${SidebarMode}`;
-    title_color?: string;
-    subtitle_color?: string;
-    sidebar_background?: string;
-    sidebar_button_color?: string;
-    sidebar_border_color?: string;
-    menu_background?: string;
-    divider_color?: string;
-    divider_top_color?: string;
-    divider_bottom_color?: string;
-    scrollbar_thumb_color?: string;
     styles?: string;
 }
 


### PR DESCRIPTION
This pull request creates constants to map options to CSS variables to avoid code repetition.

>[!IMPORTANT]
>Some variables have been renamed:
>* `--custom-sidebar-selected-text-color` to `--custom-sidebar-text-color-selected`
>* `--custom-sidebar-selected-icon-color` to `--custom-sidebar-icon-color-selected`
>* `--custom-sidebar-selected-info-color` to `--custom-sidebar-info-color-selected`