### PR TITLE
Avoid running the HACS action in forks, because forks don't have releases

### DIFF
--- a/.github/workflows/hacs.yaml
+++ b/.github/workflows/hacs.yaml
@@ -10,10 +10,10 @@ jobs:
   hacs:
     name: HACS Action
     runs-on: "ubuntu-latest"
-    if: github.repository == 'elchininet/custom-sidebar'
     steps:
       - uses: "actions/checkout@v3"
-      - name: HACS Action
+      - if: github.repository == 'elchininet/custom-sidebar'
+        name: HACS Action
         uses: "hacs/action@main"
         with:
           category: "plugin"

--- a/.github/workflows/hacs.yaml
+++ b/.github/workflows/hacs.yaml
@@ -10,6 +10,7 @@ jobs:
   hacs:
     name: HACS Action
     runs-on: "ubuntu-latest"
+    if: github.repository == 'elchininet/custom-sidebar'
     steps:
       - uses: "actions/checkout@v3"
       - name: HACS Action


### PR DESCRIPTION
Forks don't have releases. If a pull request is created from another repo avoid running the HACS action because it will always fail.