### PR TITLE
Change the pull_request event by pull_request_target

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -4,12 +4,18 @@ on:
   push:
     branches:
       - master
-  pull_request:
+  pull_request_target:
+    types: [opened, synchronize]
 
 jobs:      
   test:
     runs-on: ubuntu-22.04
     steps:
+      - name: Check access
+        if: ${{ github.event.pull_request.author_association != 'COLLABORATOR' && github.event.pull_request.author_association != 'OWNER' }}
+        run: |
+          echo "No authorized to run this workflow!"
+          exit 1
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install pnpm


### PR DESCRIPTION
This pull request changes the event trigger of the test workflow from `pull_request` to `pull_request_target` to be able to access secrets from pull request from forks. An pre-step has been added to check that the `author_association` is owner or collaborator, to prevent the workflow run insecurely without checking the changes in the PR.