### PR TITLE
Remove the pull_request_target types

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
   pull_request_target:
-    types: [opened, synchronize]
 
 jobs:      
   test:


### PR DESCRIPTION
Removing the types from the `pull_request_target` so it will run also on reopens.