### PR TITLE
Avoid HACS running twice in pull requests

### DIFF
--- a/.github/workflows/hacs.yaml
+++ b/.github/workflows/hacs.yaml
@@ -2,6 +2,8 @@ name: HACS Action
 
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: "0 0 * * *"


### PR DESCRIPTION
HACS is running twice in pull requests, one for the `push` event and another one for the `pull_request`. This pull request adds a condition to run the `push` event only on master.