### PR TITLE
fix a bug related to reactive variables declaration

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -243,4 +243,4 @@ export const JS_TEMPLATE_REG = /^\s*\[\[\[([\s\S]+)\]\]\]\s*$/;
 export const JINJA_TEMPLATE_REG = /\{\{[\s\S]*\}\}|\{%[\s\S]*%\}/;
 export const PARTIAL_REGEXP = /@partial\s+([\w-]+)/g;
 export const DOMAIN_ENTITY_REGEXP = /^\s*([a-z_]+)\.([\w-]+)\s*$/;
-export const REF_VARIABLE_REGEXP = /^ref\(([\s\S]*)\)$/;
+export const REF_VARIABLE_REGEXP = /^\s*ref\(([\s\S]*)\)\s*$/;


### PR DESCRIPTION
This pull request fixes a bug related to some reactive variables not being initialised in the `js_variables` option.