### PR TITLE
Move code blocks to markdown partials

### DIFF
--- a/docs/docs/02-installation.mdx
+++ b/docs/docs/02-installation.mdx
@@ -2,8 +2,8 @@
 sidebar_position: 2
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
+import InstallThroughHacsExample from './_partials/installation/_installation-trough-hacs.mdx';
+import InstallationManualExample from './_partials/installation/_installation-manual.mdx';
 
 # Installation
 
@@ -17,22 +17,7 @@ You can install the plugin manually or through [HACS], not both. **If you instal
 4. Click on `Download` in the more-info dialog
 5. When the plugin is already downloaded, add the url of the plugin as an [extra_module_url] in your `configuration.yaml`:
 
-<Tabs groupId="config">
-  <TabItem value="yaml" label="If you want to use a YAML configuration" default>
-    ```yaml title="configuration.yaml"
-    frontend:
-      extra_module_url:
-        - /hacsfiles/custom-sidebar/custom-sidebar-yaml.js
-    ```
-  </TabItem>
-  <TabItem value="json" label="If you want to use a JSON configuration">
-    ```yaml title="configuration.yaml"
-    frontend:
-      extra_module_url:
-        - /hacsfiles/custom-sidebar/custom-sidebar-json.js
-    ```
-  </TabItem>
-</Tabs>
+<InstallThroughHacsExample />
 
 6. Restart Home Assistant
 
@@ -49,22 +34,7 @@ You can install the plugin manually or through [HACS], not both. **If you instal
 2. Copy `custom-sidebar-yaml.js` or `custom-sidebar-json.js` into `<config directory>/www/` (depending on the configuration format that you are going to use,  `YAML` or `JSON`)
 3. Add the url of the plugin as an [extra_module_url] in your `configuration.yaml`:
 
-<Tabs groupId="config">
-  <TabItem value="yaml" label="If you want to use a YAML configuration" default>
-    ```yaml title="configuration.yaml"
-    frontend:
-      extra_module_url:
-        - /local/custom-sidebar-yaml.js?v1.0.0
-    ```
-  </TabItem>
-  <TabItem value="json" label="If you want to use a JSON configuration">
-    ```yaml title="configuration.yaml"
-    frontend:
-      extra_module_url:
-        - /local/custom-sidebar-json.js?v1.0.0
-    ```
-  </TabItem>
-</Tabs>
+<InstallationManualExample />
 
 4. Restart Home Assistant
 

--- a/docs/docs/03-configuration/02-main-configuration-options.mdx
+++ b/docs/docs/03-configuration/02-main-configuration-options.mdx
@@ -2,8 +2,8 @@
 sidebar_position: 2
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
+import RootConfigurationOptionsExample from './_partials/main-configuration-options/_root-configuration-options.mdx';
+import OrderItemPropertiesExample from './_partials/main-configuration-options/_order-item-properties.mdx';
 
 # Main Configuration Options
 
@@ -41,22 +41,7 @@ These options are intended to change the functionality of the sidebar and to cha
 
 ### Short Configuration Example
 
-<Tabs groupId="config">
-  <TabItem value="yaml" label="YAML" default>
-    ```yaml title="<config directory>/www/sidebar-config.yaml"
-    title: 'My Home'
-    sidebar_editable: false
-    ```
-  </TabItem>
-  <TabItem value="json" label="JSON">
-    ```json title="<config directory>/www/sidebar-config.json"
-    {
-      "title": "My Home",
-      "sidebar_editable": false
-    }
-    ```
-  </TabItem>
-</Tabs>
+<RootConfigurationOptionsExample />
 
 ## Order Items Properties
 
@@ -99,80 +84,7 @@ These options are intended to change the functionality of the sidebar and to cha
 
 ### Short Configuration Example
 
-<Tabs groupId="config">
-  <TabItem value="yaml" label="YAML" default>
-    ```yaml title="<config directory>/www/sidebar-config.yaml"
-    title: 'My Home'
-    order:
-      - new_item: true
-        item: 'Automations'
-        href: '/config/automation'
-        icon: 'mdi:robot'
-        order: 1
-      - new_item: true
-        item: 'Woonkamer'
-        icon: 'mdi:ceiling-light-multiple'
-        on_click:
-          action: 'call-service'
-          service: 'light.toggle'
-          data:
-            entity_id: 'light.woonkamer'
-        order: 2
-      - new_item: true
-        item: 'Reload'
-        icon: 'mdi:reload-alert'
-        on_click:
-          action: 'javascript'
-          code: 'location.reload();'
-        order: 3
-      - item: 'overview'
-        hide: true
-    ```
-  </TabItem>
-  <TabItem value="json" label="JSON">
-    ```json title="<config directory>/www/sidebar-config.json"
-    {
-      "title": "My Home",
-      "order": [
-        {
-          "new_item": true,
-          "item": "Automations",
-          "href": "/config/automation",
-          "icon": "mdi:robot",
-          "order": 1
-        },
-        {
-          "new_item": true,
-          "item": "Woonkamer",
-          "icon": "mdi:ceiling-light-multiple",
-          "on_click": {
-            "action": "call-service",
-            "service": "light.toggle",
-            "data": {
-              "entity_id": "light.woonkamer"
-            }
-          },
-          "order": 2
-        },
-        {
-          "new_item": true,
-          "item": "Reload",
-          "icon": "mdi:reload-alert",
-          "on_click": {
-            "action": "javascript",
-            "code": "location.reload();"
-          },
-          "order": 3
-        },
-        {
-          "item": "overview",
-          "hide": true
-        }
-      ]
-    }
-    ```
-  </TabItem>
-</Tabs>
+<OrderItemPropertiesExample />
 
 ## Advanced Configuration Options
 

--- a/docs/docs/03-configuration/03-themeable-configuration-options.mdx
+++ b/docs/docs/03-configuration/03-themeable-configuration-options.mdx
@@ -2,8 +2,8 @@
 sidebar_position: 3
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
+import RootConfigurationOptionsExample from './_partials/themeable-configuration-options/_root-configuration-options.mdx';
+import OrderItemPropertiesExample from './_partials/themeable-configuration-options/_order-item-properties.mdx';
 
 # Themeable Configuration Options
 
@@ -56,30 +56,7 @@ These options are only useful if you plan to change the appareance of the sideba
 
 ### Short Configuration Example
 
-<Tabs groupId="config">
-  <TabItem value="yaml" label="YAML" default>
-    ```yaml title="<config directory>/www/sidebar-config.yaml"
-    title: 'My Home'
-    // highlight-next-line
-    title_color: 'var(--accent-color)'
-    subtitle: 'Welcome!'
-    // highlight-next-line
-    subtitle_color: 'var(--primary-color)'
-    ```
-  </TabItem>
-  <TabItem value="json" label="JSON">
-    ```json title="<config directory>/www/sidebar-config.json"
-    {
-      "title": "My Home",
-      // highlight-next-line
-      "title_color": "var(--accent-color)",
-      "subtitle": "Welcome!",
-      // highlight-next-line
-      "subtitle_color": "var(--primary-color)"
-    }
-    ```
-  </TabItem>
-</Tabs>
+<RootConfigurationOptionsExample />
 
 ## Order Items Properties
 
@@ -114,44 +91,4 @@ These options are only useful if you plan to change the appareance of the sideba
 
 ### Short Configuration Example
 
-<Tabs groupId="config">
-  <TabItem value="yaml" label="YAML" default>
-    ```yaml title="<config directory>/www/sidebar-config.yaml"
-    title: 'My Home'
-    icon_color_selected: 'var(--accent-color)'
-    order:
-      - item: 'overview'
-        order: 1
-      - new_item: true
-        item: 'Automations'
-        href: '/config/automation'
-        icon: 'mdi:robot'
-        // highlight-next-line
-        icon_color_selected: 'var(--success-color)'
-        order: 2
-    ```
-  </TabItem>
-  <TabItem value="json" label="JSON">
-    ```json title="<config directory>/www/sidebar-config.json"
-    {
-      "title": "My Home",
-      "icon_color_selected": "var(--accent-color)",
-      "order": [
-        {
-          "item": "overview",
-          "order": 1
-        },
-        {
-          "new_item": true,
-          "item": "Automations",
-          "href": "/config/automation",
-          "icon": "mdi:robot",
-          // highlight-next-line
-          "icon_color_selected": "var(--success-color)",
-          "order": 2
-        }
-      ]
-    }
-    ```
-  </TabItem>
-</Tabs>
+<OrderItemPropertiesExample />

--- a/docs/docs/03-configuration/04-exceptions.mdx
+++ b/docs/docs/03-configuration/04-exceptions.mdx
@@ -2,8 +2,7 @@
 sidebar_position: 4
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
+import ExceptionsExample from './_partials/exceptions/_exceptions.mdx';
 
 # Exceptions
 
@@ -39,67 +38,4 @@ In an exception you can define all the configuration options (excluding the [Adv
 
 ### Short Configuration Example
 
-<Tabs groupId="config">
-  <TabItem value="yaml" label="YAML" default>
-    ```yaml title="<config directory>/www/sidebar-config.yaml"
-    exceptions:
-      - user:
-        - 'Jim Hawkins'
-        - 'Long John Silver'
-        extend_from: 'base'
-        title: 'My Home'
-        order:
-          ...
-      - not_user:
-        - 'John Doe'
-        - 'Jack Sparrow'
-        is_admin: true
-        matchers_conditions: 'AND'
-        order:
-          ...
-      - not_device: 'Android'
-        order:
-          ...
-      - is_admin: true
-        order:
-          ...
-    ```
-  </TabItem>
-  <TabItem value="json" label="JSON">
-    ```json title="<config directory>/www/sidebar-config.json"
-    {
-      ...
-      "exceptions": [
-        {
-          "user": ["Jim Hawkins", "Long John Silver"],
-          "extend_from": "base",
-          "title": "My Home",
-          "order": [
-            ...
-          ]
-        },
-        {
-          "not_user": ["John Doe", "Jack Sparrow"],
-          "is_admin": true,
-          "matchers_conditions": "AND",
-          "order": [
-            ...
-          ]
-        },
-        {
-          "not_device": "Android",
-          "order": [
-             ...
-          ]
-        },
-        {
-          "is_admin": true,
-          "order": [
-            ...
-          ]
-        }
-      ]  
-    }
-    ```
-  </TabItem>
-</Tabs>
+<ExceptionsExample />

--- a/docs/docs/03-configuration/_partials/exceptions/_exceptions.mdx
+++ b/docs/docs/03-configuration/_partials/exceptions/_exceptions.mdx
@@ -1,0 +1,67 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs groupId="config">
+  <TabItem value="yaml" label="YAML" default>
+    ```yaml title="<config directory>/www/sidebar-config.yaml"
+    exceptions:
+      - user:
+        - 'Jim Hawkins'
+        - 'Long John Silver'
+        extend_from: 'base'
+        title: 'My Home'
+        order:
+          ...
+      - not_user:
+        - 'John Doe'
+        - 'Jack Sparrow'
+        is_admin: true
+        matchers_conditions: 'AND'
+        order:
+          ...
+      - not_device: 'Android'
+        order:
+          ...
+      - is_admin: true
+        order:
+          ...
+    ```
+  </TabItem>
+  <TabItem value="json" label="JSON">
+    ```json title="<config directory>/www/sidebar-config.json"
+    {
+      ...
+      "exceptions": [
+        {
+          "user": ["Jim Hawkins", "Long John Silver"],
+          "extend_from": "base",
+          "title": "My Home",
+          "order": [
+            ...
+          ]
+        },
+        {
+          "not_user": ["John Doe", "Jack Sparrow"],
+          "is_admin": true,
+          "matchers_conditions": "AND",
+          "order": [
+            ...
+          ]
+        },
+        {
+          "not_device": "Android",
+          "order": [
+             ...
+          ]
+        },
+        {
+          "is_admin": true,
+          "order": [
+            ...
+          ]
+        }
+      ]  
+    }
+    ```
+  </TabItem>
+</Tabs>

--- a/docs/docs/03-configuration/_partials/main-configuration-options/_order-item-properties.mdx
+++ b/docs/docs/03-configuration/_partials/main-configuration-options/_order-item-properties.mdx
@@ -1,0 +1,77 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs groupId="config">
+  <TabItem value="yaml" label="YAML" default>
+    ```yaml title="<config directory>/www/sidebar-config.yaml"
+    title: 'My Home'
+    order:
+      - new_item: true
+        item: 'Automations'
+        href: '/config/automation'
+        icon: 'mdi:robot'
+        order: 1
+      - new_item: true
+        item: 'Woonkamer'
+        icon: 'mdi:ceiling-light-multiple'
+        on_click:
+          action: 'call-service'
+          service: 'light.toggle'
+          data:
+            entity_id: 'light.woonkamer'
+        order: 2
+      - new_item: true
+        item: 'Reload'
+        icon: 'mdi:reload-alert'
+        on_click:
+          action: 'javascript'
+          code: 'location.reload();'
+        order: 3
+      - item: 'overview'
+        hide: true
+    ```
+  </TabItem>
+  <TabItem value="json" label="JSON">
+    ```json title="<config directory>/www/sidebar-config.json"
+    {
+      "title": "My Home",
+      "order": [
+        {
+          "new_item": true,
+          "item": "Automations",
+          "href": "/config/automation",
+          "icon": "mdi:robot",
+          "order": 1
+        },
+        {
+          "new_item": true,
+          "item": "Woonkamer",
+          "icon": "mdi:ceiling-light-multiple",
+          "on_click": {
+            "action": "call-service",
+            "service": "light.toggle",
+            "data": {
+              "entity_id": "light.woonkamer"
+            }
+          },
+          "order": 2
+        },
+        {
+          "new_item": true,
+          "item": "Reload",
+          "icon": "mdi:reload-alert",
+          "on_click": {
+            "action": "javascript",
+            "code": "location.reload();"
+          },
+          "order": 3
+        },
+        {
+          "item": "overview",
+          "hide": true
+        }
+      ]
+    }
+    ```
+  </TabItem>
+</Tabs>

--- a/docs/docs/03-configuration/_partials/main-configuration-options/_root-configuration-options.mdx
+++ b/docs/docs/03-configuration/_partials/main-configuration-options/_root-configuration-options.mdx
@@ -1,0 +1,19 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs groupId="config">
+  <TabItem value="yaml" label="YAML" default>
+    ```yaml title="<config directory>/www/sidebar-config.yaml"
+    title: 'My Home'
+    sidebar_editable: false
+    ```
+  </TabItem>
+  <TabItem value="json" label="JSON">
+    ```json title="<config directory>/www/sidebar-config.json"
+    {
+      "title": "My Home",
+      "sidebar_editable": false
+    }
+    ```
+  </TabItem>
+</Tabs>

--- a/docs/docs/03-configuration/_partials/themeable-configuration-options/_order-item-properties.mdx
+++ b/docs/docs/03-configuration/_partials/themeable-configuration-options/_order-item-properties.mdx
@@ -1,0 +1,44 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs groupId="config">
+  <TabItem value="yaml" label="YAML" default>
+    ```yaml title="<config directory>/www/sidebar-config.yaml"
+    title: 'My Home'
+    icon_color_selected: 'var(--accent-color)'
+    order:
+      - item: 'overview'
+        order: 1
+      - new_item: true
+        item: 'Automations'
+        href: '/config/automation'
+        icon: 'mdi:robot'
+        // highlight-next-line
+        icon_color_selected: 'var(--success-color)'
+        order: 2
+    ```
+  </TabItem>
+  <TabItem value="json" label="JSON">
+    ```json title="<config directory>/www/sidebar-config.json"
+    {
+      "title": "My Home",
+      "icon_color_selected": "var(--accent-color)",
+      "order": [
+        {
+          "item": "overview",
+          "order": 1
+        },
+        {
+          "new_item": true,
+          "item": "Automations",
+          "href": "/config/automation",
+          "icon": "mdi:robot",
+          // highlight-next-line
+          "icon_color_selected": "var(--success-color)",
+          "order": 2
+        }
+      ]
+    }
+    ```
+  </TabItem>
+</Tabs>

--- a/docs/docs/03-configuration/_partials/themeable-configuration-options/_root-configuration-options.mdx
+++ b/docs/docs/03-configuration/_partials/themeable-configuration-options/_root-configuration-options.mdx
@@ -1,0 +1,27 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs groupId="config">
+  <TabItem value="yaml" label="YAML" default>
+    ```yaml title="<config directory>/www/sidebar-config.yaml"
+    title: 'My Home'
+    // highlight-next-line
+    title_color: 'var(--accent-color)'
+    subtitle: 'Welcome!'
+    // highlight-next-line
+    subtitle_color: 'var(--primary-color)'
+    ```
+  </TabItem>
+  <TabItem value="json" label="JSON">
+    ```json title="<config directory>/www/sidebar-config.json"
+    {
+      "title": "My Home",
+      // highlight-next-line
+      "title_color": "var(--accent-color)",
+      "subtitle": "Welcome!",
+      // highlight-next-line
+      "subtitle_color": "var(--primary-color)"
+    }
+    ```
+  </TabItem>
+</Tabs>

--- a/docs/docs/04-templates/02-javascript-templates.mdx
+++ b/docs/docs/04-templates/02-javascript-templates.mdx
@@ -2,8 +2,7 @@
 sidebar_position: 2
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
+import JavaScriptTemplateExample from './_partials/javascript-templates/_javascript-templates.mdx';
 
 # JavaScript Templates
 
@@ -24,62 +23,7 @@ The next example will set the next options:
 3. Adds the number of `HACS` updates as a notification in the `HACS` item in the sidebar. In case that there are no updates, an empty string is returned and in these cases the notification will not be displayed.
 4. Creates a new item that redirects to the `Home Assistant` info page with a dynamic text with the word "Info" followed by the installed Supervisor version  between parentheses and the Operating System version in the info text.
 
-<Tabs groupId="config">
-  <TabItem value="yaml" label="YAML" default>
-    ```yaml title="<config directory>/www/sidebar-config.yaml"
-    title: '[[[ "My Home " + new Date(states("sensor.date_time_iso")).toLocaleTimeString().slice(0, 5) ]]]'
-    sidebar_background: |
-      [[[
-        return panel_url === '/config/dashboard'
-          ? 'red'
-          : 'green';
-      ]]]
-    order:
-      - item: hacs
-        notification: |
-          [[[
-            const outdatedHacsEntities = Object.values(entities.update).filter(
-              (entity) => entity.platform === 'hacs' && is_state(entity.entity_id, 'on')
-            );
-            return outdatedHacsEntities.length || '';
-          ]]]
-      - new_item: true
-        item: info
-        name: |
-          [[[
-            return 'Info (' + state_attr('update.home_assistant_supervisor_update', 'latest_version') + ')';
-          ]]]
-        info: |
-          [[[
-            return 'OS ' + state_attr('update.home_assistant_operating_system_update', 'latest_version');
-          ]]]
-        href: '/config/info'
-        icon: 'mdi:information-outline'
-    ```
-  </TabItem>
-  <TabItem value="json" label="JSON">
-    ```json title="<config directory>/www/sidebar-config.json"
-    {
-      "title": "[[[ 'My Home ' + new Date(states('sensor.date_time_iso')).toLocaleTimeString().slice(0, 5) ]]]",
-      "sidebar_background": "[[[ return panel_url === '/config/dashboard' ? 'red' : 'green' ]]]",
-      "order": [
-        {
-          "item": "hacs",
-          "notification": "[[[ return Object.values(entities.update).filter((entity) => entity.platform === 'hacs' && is_state(entity.entity_id, 'on')).length || '' ]]]"
-        },
-        {
-          "new_item": true,
-          "item": "info",
-          "name": "[[[ return 'Info (' + state_attr('update.home_assistant_supervisor_update', 'latest_version') + ')'; ]]]",
-          "info": "[[[ return 'OS ' + state_attr('update.home_assistant_operating_system_update', 'latest_version'); ]]]",
-          "href": "/config/info",
-          "icon": "mdi:information-outline"
-        }
-      ]
-    }
-    ```
-  </TabItem>
-</Tabs>
+<JavaScriptTemplateExample />
 
 :::tip
 

--- a/docs/docs/04-templates/03-jinja-templates.mdx
+++ b/docs/docs/04-templates/03-jinja-templates.mdx
@@ -2,8 +2,7 @@
 sidebar_position: 3
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
+import JinjaTemplatesExample from './_partials/jinja-templates/_jinja-templates.mdx';
 
 # Jinja Templates
 
@@ -24,49 +23,4 @@ The next example will set the next options:
 2. Adds the number of `HACS` updates as a notification in the `HACS` item in the sidebar. In case that there are no updates, an empty string is returned and in these cases the notification will not be displayed.
 3. Creates a new item that redirects to the `Home Assistant` info page with a dynamic text with the word "Info" followed by the installed Supervisor version between parentheses and the Operating System version in the info text.
 
-<Tabs groupId="config">
-  <TabItem value="yaml" label="YAML" default>
-    ```yaml title="<config directory>/www/sidebar-config.yaml"
-    title: 'My Home {{ as_timestamp(states("sensor.date_time_iso")) | timestamp_custom("%H:%M") }}'
-    order:
-      - item: 'hacs'
-        notification: |
-          {{
-            expand(states.update)
-            | selectattr('state', 'eq', 'on')
-            | map(attribute='entity_id')
-            | map('device_attr', 'identifiers')
-            | map('contains', 'hacs')
-            | list
-            | length or ""
-          }}
-      - new_item: true
-        item: 'info'
-        name: 'Info ({{ state_attr("update.home_assistant_supervisor_update", "latest_version") }})'
-        info: 'OS {{ state_attr("update.home_assistant_operating_system_update", "latest_version") }}'
-        href: '/config/info'
-        icon: 'mdi:information-outline'
-    ```
-  </TabItem>
-  <TabItem value="json" label="JSON">
-    ```json title="<config directory>/www/sidebar-config.json"
-    {
-      "title": "My Home {{ as_timestamp(states('sensor.date_time_iso')) | timestamp_custom('%H:%M') }}",
-      "order": [
-        {
-          "item": "hacs",
-          "notification": "{{ expand(states.update) | selectattr('state', 'eq', 'on') | map(attribute='entity_id') | map('device_attr', 'identifiers') | map('contains', 'hacs') | list | length or '' }}"
-        },
-        {
-          "new_item": true,
-          "item": "info",
-          "name": "Info ({{ state_attr('update.home_assistant_supervisor_update', 'latest_version') }})",
-          "info": "OS {{ state_attr('update.home_assistant_operating_system_update', 'latest_version') }}",
-          "href": "/config/info",
-          "icon": "mdi:information-outline"
-        }
-      ]
-    }
-    ```
-  </TabItem>
-</Tabs>
+<JinjaTemplatesExample />

--- a/docs/docs/04-templates/_partials/javascript-templates/_javascript-templates.mdx
+++ b/docs/docs/04-templates/_partials/javascript-templates/_javascript-templates.mdx
@@ -1,0 +1,59 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs groupId="config">
+  <TabItem value="yaml" label="YAML" default>
+    ```yaml title="<config directory>/www/sidebar-config.yaml"
+    title: '[[[ "My Home " + new Date(states("sensor.date_time_iso")).toLocaleTimeString().slice(0, 5) ]]]'
+    sidebar_background: |
+      [[[
+        return panel_url === '/config/dashboard'
+          ? 'red'
+          : 'green';
+      ]]]
+    order:
+      - item: hacs
+        notification: |
+          [[[
+            const outdatedHacsEntities = Object.values(entities.update).filter(
+              (entity) => entity.platform === 'hacs' && is_state(entity.entity_id, 'on')
+            );
+            return outdatedHacsEntities.length || '';
+          ]]]
+      - new_item: true
+        item: info
+        name: |
+          [[[
+            return 'Info (' + state_attr('update.home_assistant_supervisor_update', 'latest_version') + ')';
+          ]]]
+        info: |
+          [[[
+            return 'OS ' + state_attr('update.home_assistant_operating_system_update', 'latest_version');
+          ]]]
+        href: '/config/info'
+        icon: 'mdi:information-outline'
+    ```
+  </TabItem>
+  <TabItem value="json" label="JSON">
+    ```json title="<config directory>/www/sidebar-config.json"
+    {
+      "title": "[[[ 'My Home ' + new Date(states('sensor.date_time_iso')).toLocaleTimeString().slice(0, 5) ]]]",
+      "sidebar_background": "[[[ return panel_url === '/config/dashboard' ? 'red' : 'green' ]]]",
+      "order": [
+        {
+          "item": "hacs",
+          "notification": "[[[ return Object.values(entities.update).filter((entity) => entity.platform === 'hacs' && is_state(entity.entity_id, 'on')).length || '' ]]]"
+        },
+        {
+          "new_item": true,
+          "item": "info",
+          "name": "[[[ return 'Info (' + state_attr('update.home_assistant_supervisor_update', 'latest_version') + ')'; ]]]",
+          "info": "[[[ return 'OS ' + state_attr('update.home_assistant_operating_system_update', 'latest_version'); ]]]",
+          "href": "/config/info",
+          "icon": "mdi:information-outline"
+        }
+      ]
+    }
+    ```
+  </TabItem>
+</Tabs>

--- a/docs/docs/04-templates/_partials/jinja-templates/_jinja-templates.mdx
+++ b/docs/docs/04-templates/_partials/jinja-templates/_jinja-templates.mdx
@@ -1,0 +1,49 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs groupId="config">
+  <TabItem value="yaml" label="YAML" default>
+    ```yaml title="<config directory>/www/sidebar-config.yaml"
+    title: 'My Home {{ as_timestamp(states("sensor.date_time_iso")) | timestamp_custom("%H:%M") }}'
+    order:
+      - item: 'hacs'
+        notification: |
+          {{
+            expand(states.update)
+            | selectattr('state', 'eq', 'on')
+            | map(attribute='entity_id')
+            | map('device_attr', 'identifiers')
+            | map('contains', 'hacs')
+            | list
+            | length or ""
+          }}
+      - new_item: true
+        item: 'info'
+        name: 'Info ({{ state_attr("update.home_assistant_supervisor_update", "latest_version") }})'
+        info: 'OS {{ state_attr("update.home_assistant_operating_system_update", "latest_version") }}'
+        href: '/config/info'
+        icon: 'mdi:information-outline'
+    ```
+  </TabItem>
+  <TabItem value="json" label="JSON">
+    ```json title="<config directory>/www/sidebar-config.json"
+    {
+      "title": "My Home {{ as_timestamp(states('sensor.date_time_iso')) | timestamp_custom('%H:%M') }}",
+      "order": [
+        {
+          "item": "hacs",
+          "notification": "{{ expand(states.update) | selectattr('state', 'eq', 'on') | map(attribute='entity_id') | map('device_attr', 'identifiers') | map('contains', 'hacs') | list | length or '' }}"
+        },
+        {
+          "new_item": true,
+          "item": "info",
+          "name": "Info ({{ state_attr('update.home_assistant_supervisor_update', 'latest_version') }})",
+          "info": "OS {{ state_attr('update.home_assistant_operating_system_update', 'latest_version') }}",
+          "href": "/config/info",
+          "icon": "mdi:information-outline"
+        }
+      ]
+    }
+    ```
+  </TabItem>
+</Tabs>

--- a/docs/docs/05-advanced-configuration-options/02-javascript-variables.mdx
+++ b/docs/docs/05-advanced-configuration-options/02-javascript-variables.mdx
@@ -2,8 +2,9 @@
 sidebar_position: 2
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
+import JavaScriptVariablesExample from './_partials/javascript-variables/_javascript-variables.mdx';
+import ReactiveVariablesExample from './_partials/javascript-variables/_reactive-variables.mdx';
+import ReactiveVariablesWorkingExample from './_partials/javascript-variables/_reactive-variables-working.mdx';
 
 # JavaScript Variables
 
@@ -20,51 +21,7 @@ import TabItem from '@theme/TabItem';
 
 The next example will set "Title 80 dog" as the title of the page:
 
-<Tabs groupId="config">
-  <TabItem value="yaml" label="YAML" default>
-    ```yaml title="<config directory>/www/sidebar-config.yaml"
-    js_variables:
-      my_string: 'Title'
-      my_number: 100
-      my_boolean: true
-      my_object:
-        prop1: 4
-        prop2: 5
-      my_array:
-        - 'cat'
-        - 'dog'
-        - 'bird'
-    title: |
-      [[[
-        if (my_boolean) {
-          return `${my_string} ${(my_number * my_object.prop1) / my_object.prop2} ${my_array[1]}`;
-        }
-        return 'Home Assistant';
-      ]]]
-    ```
-  </TabItem>
-  <TabItem value="json" label="JSON">
-    ```json title="<config directory>/www/sidebar-config.json"
-    {
-      "js_variables": {
-        "my_string": "Title",
-        "my_number": 100,
-        "my_boolean": true,
-        "my_object": {
-          "prop1": 4,
-          "prop2": 5
-        },
-        "my_array": [
-          "cat",
-          "dog",
-          "bird"
-        ]
-      },
-      "title": "return (my_boolean) ? `${my_string} ${(my_number * my_object.prop1) / my_object.prop2} ${my_array[1]}` : 'Home Assistant';"
-    }
-    ```
-  </TabItem>
-</Tabs>
+<JavaScriptVariablesExample />
 
 ## Reactive JavaScript Variables
 
@@ -72,128 +29,11 @@ Reactive variables will make your templates be reactive to changes in local vari
 
 You can define a reactive variable in the `js_variables` option, and later use or change its value in a template. To defined a reactive variable with an initial value, just create a string variable in the `js_variables` wrapped by the special method `ref`. To use it in a template, just access it with the same special `ref` method and then retrieve its `value` property. For example, let's change the previous example to use reactive variables:
 
-<Tabs groupId="config">
-  <TabItem value="yaml" label="YAML" default>
-    ```yaml title="<config directory>/www/sidebar-config.yaml"
-    js_variables:
-      my_string: 'ref("Title")'
-      my_number: 'ref(100)'
-      my_boolean: 'ref(true)'
-      my_object: |
-        ref({
-          prop1: 4,
-          prop2: 5
-        })
-      my_array: |
-        ref([
-          'cat',
-          'dog',
-          'bird'
-        ])
-    title: |
-      [[[
-        const my_boolean = ref('my_boolean').value;
-        const my_string = ref('my_string').value;
-        const my_number = ref('my_number').value;
-        const my_object = ref('my_object').value;
-        const my_array = ref('my_array').value;
-        if (my_boolean) {
-          return `${my_string} ${(my_number * my_object.prop1) / my_object.prop2} ${my_array[1]}`;
-        }
-        return 'Home Assistant';
-      ]]]
-    ```
-  </TabItem>
-  <TabItem value="json" label="JSON">
-    ```json title="<config directory>/www/sidebar-config.json"
-    {
-      "js_variables": {
-        "my_string": "ref('Title')",
-        "my_number": "ref(100)",
-        "my_boolean": "ref(true)",
-        "my_object": "ref({ prop1: 4, prop2: 5 })",
-        "my_array": "ref(['cat', 'dog', 'bird'])"
-      },
-      "title": "[[[ const my_boolean = ref('my_boolean').value, my_string = ref('my_string').value, my_number = ref('my_number').value, my_object = ref('my_object').value, my_array = ref('my_array').value; return my_boolean ? `${my_string} ${(my_number * my_object.prop1) / my_object.prop2} ${my_array[1]}` : 'Home Assistant' ]]]"
-    }
-    ```
-  </TabItem>
-</Tabs>
+<ReactiveVariablesExample />
 
 Now it is possible to change the value of any of these variables and the title template will be reevaluated using the new values. For example, let's modify the value of some of these variables when an item in the sidebar is clicked and let's check what will be the value of the `title` on each click.
 
-<Tabs groupId="config">
-  <TabItem value="yaml" label="YAML" default>
-    ```yaml title="<config directory>/www/sidebar-config.yaml"
-    js_variables:
-      my_string: 'ref("Title")'
-      my_number: 'ref(100)'
-      my_boolean: 'ref(true)'
-      my_object: |
-        ref({
-          prop1: 4,
-          prop2: 5
-        })
-      my_array: |
-        ref([
-          'cat',
-          'dog',
-          'bird'
-        ])
-    title: |
-      [[[
-        const my_boolean = ref('my_boolean').value;
-        const my_string = ref('my_string').value;
-        const my_number = ref('my_number').value;
-        const my_object = ref('my_object').value;
-        const my_array = ref('my_array').value;
-        if (my_boolean) {
-          return `${my_string} ${(my_number * my_object.prop1) / my_object.prop2} ${my_array[1]}`;
-        }
-        return 'Home Assistant';
-      ]]]
-    order:
-      - new_item: true
-        item: 'Example'
-        icon: 'mdi:gesture-tap'
-        on_click:
-          action: 'javascript'
-          code: |
-            const my_number = ref('my_number');
-            const my_object = ref('my_object');
-            my_number.value *= 2;
-            my_object.value = {
-                ...my_object.value,
-                prop1: my_object.value.prop1 + 2
-            };
-    ```
-  </TabItem>
-  <TabItem value="json" label="JSON">
-    ```json title="<config directory>/www/sidebar-config.json"
-    {
-      "js_variables": {
-        "my_string": "ref('Title')",
-        "my_number": "ref(100)",
-        "my_boolean": "ref(true)",
-        "my_object": "ref({ prop1: 4, prop2: 5 })",
-        "my_array": "ref(['cat', 'dog', 'bird'])"
-      },
-      "title": "[[[ const my_boolean = ref('my_boolean').value, my_string = ref('my_string').value, my_number = ref('my_number').value, my_object = ref('my_object').value, my_array = ref('my_array').value; return my_boolean ? `${my_string} ${(my_number * my_object.prop1) / my_object.prop2} ${my_array[1]}` : 'Home Assistant' ]]]",
-      "order": [
-        {
-            "new_item": true,
-            "item": "Example",
-            "icon": "mdi:gesture-tap",
-            "on_click": {
-                "action": "javascript",
-                "code": "const my_number = ref('my_number'), my_object = ref('my_object'); my_number.value *= 2; my_object.value = { ...my_object.value, prop1: my_object.value.prop1 + 2 }"
-            }
-        }
-      ]
-    }
-    ```
-  </TabItem>
-</Tabs>
+<ReactiveVariablesWorkingExample />
 
 ### Value of the `title` after each click:
 

--- a/docs/docs/05-advanced-configuration-options/03-jinja-variables.mdx
+++ b/docs/docs/05-advanced-configuration-options/03-jinja-variables.mdx
@@ -2,8 +2,7 @@
 sidebar_position: 3
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
+import JinjaVariablesExample from './_partials/jinja-variables/_jinja-variables.mdx';
 
 # Jinja Variables
 
@@ -20,47 +19,4 @@ import TabItem from '@theme/TabItem';
 
 The next example will set "Title 80 dog" as the title of the page:
 
-<Tabs groupId="config">
-  <TabItem value="yaml" label="YAML" default>
-    ```yaml title="<config directory>/www/sidebar-config.yaml"
-    jinja_variables:
-      my_string: Title
-      my_number: 100
-      my_boolean: true
-      my_dictionary:
-        prop1: 4
-        prop2: 5
-      my_list:
-        - cat
-        - dog
-        - bird
-      title: |
-        {% if my_boolean %}
-          {{ my_string }} {{ ((my_number * my_dictionary.prop1) / my_dictionary.prop2) | int }} {{ my_list.1 }}
-        {% else %}
-          Home Assistant
-        {% endif %}
-    ```
-  </TabItem>
-  <TabItem value="json" label="JSON">
-    ```json title="<config directory>/www/sidebar-config.json"
-    {
-      "jinja_variables": {
-        "my_string": "Title",
-        "my_number": 100,
-        "my_boolean": true,
-        "my_dictionary": {
-          "prop1": 4,
-          "prop2": 5
-        },
-        "my_list": [
-          "cat",
-          "dog",
-          "bird"
-        ]
-      },
-      "title": "{% if my_boolean %} {{ my_string }} {{ ((my_number * my_dictionary.prop1) / my_dictionary.prop2) | int }} {{ my_list.1 }} {% else %} Home Assistant {% endif %}"
-    }
-    ```
-  </TabItem>
-</Tabs>
+<JinjaVariablesExample />

--- a/docs/docs/05-advanced-configuration-options/04-partials.mdx
+++ b/docs/docs/05-advanced-configuration-options/04-partials.mdx
@@ -2,8 +2,8 @@
 sidebar_position: 4
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
+import PartialsWithJavaScriptTemplatesExample from './_partials/partials/_with-javascript-templates.mdx';
+import PartialsWithJinjaTemplatesExample from './_partials/partials/_with-jinja-templates.mdx';
 
 # Partials
 
@@ -17,126 +17,8 @@ Partials will automatically use the variables set in the `js_variables` or `jinj
 
 ### Example with JavaScript templates
 
-<Tabs groupId="config">
-  <TabItem value="yaml" label="YAML" default>
-    ```yaml title="<config directory>/www/sidebar-config.yaml"
-    js_variables:
-      supervisor_update: 'update.home_assistant_supervisor_update'
-      os_update: 'update.home_assistant_operating_system_update'
-    // highlight-start
-    partials:
-      supervisor_version: |
-        const supervisorVersion = state_attr(supervisor_update, "latest_version");
-      updates: |
-        @partial supervisor_version
-        const osVersion = state_attr(os_update, "latest_version");
-    // highlight-end
-    order:
-      - new_item: true
-        item: 'info'
-        name: |
-          [[[
-            // highlight-next-line
-            @partial updates
-            return `Info ${supervisorVersion}`;
-          ]]]
-        info: |
-          [[[
-            // highlight-next-line
-            @partial updates
-            return `OS ${ osVersion }`;
-          ]]]
-        href: '/config/info'
-        icon: 'mdi:information-outline'
-    ```
-  </TabItem>
-  <TabItem value="json" label="JSON">
-    ```json title="<config directory>/www/sidebar-config.json"
-    {
-      "js_variables": {
-        "supervisor_update": "update.home_assistant_supervisor_update",
-        "os_update": "update.home_assistant_operating_system_update"
-      },
-      // highlight-start
-      "partials": {
-        "supervisor_version": "const supervisorVersion = state_attr(supervisor_update, 'latest_version');",
-        "updates": "@partial supervisor_version const osVersion = state_attr(os_update, 'latest_version');"
-      },
-      // highlight-end
-      "order": [
-        {
-          "new_item": true,
-          "item": "info",
-          // highlight-start
-          "name": "[[[ @partial updates return `Info ${supervisorVersion}`; ]]]",
-          "info": "[[[ @partial updates return `OS ${ osVersion }`; ]]]",
-          // highlight-end
-          "href": "/config/info",
-          "icon": "mdi:information-outline"
-        }
-      ]
-    }
-    ```
-  </TabItem>
-</Tabs>
+<PartialsWithJavaScriptTemplatesExample />
 
 ### Example with Jinja templates
 
-<Tabs groupId="config">
-  <TabItem value="yaml" label="YAML" default>
-    ```yaml title="<config directory>/www/sidebar-config.yaml"
-    jinja_variables:
-      supervisor_update: 'update.home_assistant_supervisor_update'
-      os_update: 'update.home_assistant_operating_system_update'
-    // highlight-start
-    partials:
-      supervisor_version: |
-        {% set supervisorVersion = state_attr(supervisor_update, "latest_version") %}
-      updates: |
-        @partial supervisor_version
-        {% set osVersion = state_attr(os_update, "latest_version") %}
-    // highlight-end
-    order:
-      - new_item: true
-        item: 'info'
-        name: |
-          // highlight-next-line
-          @partial updates
-          Info {{ supervisorVersion }}
-        info: |
-          // highlight-next-line
-          @partial updates
-          OS {{ osVersion }}
-        href: '/config/info'
-        icon: 'mdi:information-outline'
-    ```
-  </TabItem>
-  <TabItem value="json" label="JSON">
-    ```json title="<config directory>/www/sidebar-config.json"
-    {
-      "jinja_variables": {
-        "supervisor_update": "update.home_assistant_supervisor_update",
-        "os_update": "update.home_assistant_operating_system_update"
-      },
-      // highlight-start
-      "partials": {
-        "supervisor_version": "{% set supervisorVersion = state_attr(supervisor_update, 'latest_version') %}",
-        "updates": "@partial supervisor_version {% set osVersion = state_attr(os_update, 'latest_version') %}"
-      },
-      // highlight-end
-      "order": [
-        {
-          "new_item": true,
-          "item": "info",
-          // highlight-start
-          "name": "@partial updates Info {{ supervisorVersion }}",
-          "info": "@partial updates OS {{ osVersion }}",
-          // highlight-end
-          "href": "/config/info",
-          "icon": "mdi:information-outline"
-        }
-      ]
-    }
-    ```
-  </TabItem>
-</Tabs>
+<PartialsWithJinjaTemplatesExample />

--- a/docs/docs/05-advanced-configuration-options/05-extendable-configurations.mdx
+++ b/docs/docs/05-advanced-configuration-options/05-extendable-configurations.mdx
@@ -2,8 +2,13 @@
 sidebar_position: 5
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
+import ExatendableConfigurationsExample from './_partials/extendable-configurations/_extendable-configurations.mdx';
+import ExtendableConfigurationsResultExample from './_partials/extendable-configurations/_extendable-configurations-result.mdx';
+import ExtendingFromMultipleConfigurationsExample from './_partials/extendable-configurations/_extending-from-multiple-configurations.mdx';
+import ExtendingFromAnotherExtendableConfigurationExample from './_partials/extendable-configurations/_extending-from-another-extendable-configuration.mdx';
+import ExtendingFromAnotherExtendableConfigurationResultExample from './_partials/extendable-configurations/_extending-from-another-extendable-configuration-result.mdx';
+import ExtendingFromBaseExample from './_partials/extendable-configurations/_extending-from-base.mdx';
+import ComplexExample from './_partials/extendable-configurations/_complex-example.mdx';
 
 # Extendable configurations
 
@@ -11,82 +16,7 @@ Extendable configurations (`extendable_configs`) is an object containing differe
 
 Extending from a configuration basically means _"import what I don't already have"_, so if a configuration already has an option, it will prevail and it will not be overridden if the configuration is extended. For example, the next configuration has a main configuration extending from an extendable configuration named `example`, let's analyse what will be the result of that extend.
 
-<Tabs groupId="config">
-  <TabItem value="yaml" label="YAML" default>
-    ```yaml title="<config directory>/www/sidebar-config.yaml"
-    title: 'Custom Title'
-    order:
-      - item: 'overview'
-        name: 'Dashboard'
-        order: 3
-      - new_item: true
-        item: 'Integrations'
-        href: '/config/integrations'
-        icon: 'mdi:puzzle'
-        order: 2
-    // highlight-next-line
-    extend_from: 'example'
-    extendable_configs:
-      example:
-        title: 'My Home'
-        subtitle: 'Assistant'
-        order:
-          - item: 'overview'
-            icon: 'mdi:monitor-dashboard'
-            order: 0
-          - new_item: true
-            item: 'Google'
-            href: 'https://mrdoob.com/projects/chromeexperiments/google-gravity/'
-            icon: 'mdi:earth'
-            target: '_blank'
-            order: 1
-    ```
-  </TabItem>
-  <TabItem value="json" label="JSON">
-    ```json title="<config directory>/www/sidebar-config.json"
-    {
-      "title": "Custom Title",
-      "order": [
-        {
-          "item": "overview",
-          "name": "Dashboard",
-          "order": 3
-        },
-        {
-          "new_item": true,
-          "item": "Integrations",
-          "href": "/config/integrations",
-          "icon": "mdi:puzzle",
-          "order": 2
-        }
-      ],
-      // highlight-next-line
-      "extend_from": "example",
-      "extendable_configs": {
-        "example": {
-          "title": "My Home",
-          "subtitle": "Assistant",
-          "order": [
-            {
-              "item": "overview",
-              "icon": "mdi:monitor-dashboard",
-              "order": 0
-            },
-            {
-              "new_item": true,
-              "item": "Google",
-              "href": "https://mrdoob.com/projects/chromeexperiments/google-gravity/",
-              "icon": "mdi:earth",
-              "target": "_blank",
-              "order": 1
-            }
-          ]
-        }
-      }
-    }
-    ```
-  </TabItem>
-</Tabs>
+<ExatendableConfigurationsExample />
 
 1. As the `title` option is defined in the main configuration, it will not get the `title` option from the extendable configuration.
 2. As the `subtitle` option is not defined in the main configuration, it will be get from the extendable configuration.
@@ -98,382 +28,29 @@ Extending from a configuration basically means _"import what I don't already hav
 
 The resulted main config after the extending process will be:
 
-<Tabs groupId="config">
-  <TabItem value="yaml" label="YAML" default>
-    ```yaml title="<config directory>/www/sidebar-config.yaml"
-    title: 'Custom Title'
-    subtitle: 'Assistant'
-    order:
-      - new_item: true
-        item: 'Google'
-        href: 'https://mrdoob.com/projects/chromeexperiments/google-gravity/'
-        icon: 'mdi:earth'
-        target: '_blank'
-        order: 1
-      - new_item: true
-        item: 'Integrations'
-        href: '/config/integrations'
-        icon: 'mdi:puzzle'
-        order: 2
-      - item: 'overview'
-        name: 'Dashboard'
-        icon: 'mdi:monitor-dashboard'
-        order: 3
-    ```
-  </TabItem>
-  <TabItem value="json" label="JSON">
-    ```json title="<config directory>/www/sidebar-config.json"
-    {
-      "title": "Custom Title",
-      "subtitle": "Assistant",
-      "order": [
-        {
-          "new_item": true,
-          "item": "Google",
-          "href": "https://mrdoob.com/projects/chromeexperiments/google-gravity/",
-          "icon": "mdi:earth",
-          "target": "_blank",
-          "order": 1
-        },
-        {
-          "new_item": true,
-          "item": "Integrations",
-          "href": "/config/integrations",
-          "icon": "mdi:puzzle",
-          "order": 2
-        },
-        {
-          "item": "overview",
-          "name": "Dashboard",
-          "icon": "mdi:monitor-dashboard",
-          "order": 3
-        }
-      ]
-    }
-    ```
-  </TabItem>
-</Tabs>
+<ExtendableConfigurationsResultExample />
 
 It is possible to extend from multiple configurations and they will be extended in order, as shown in the next example:
 
-<Tabs groupId="config">
-  <TabItem value="yaml" label="YAML" default>
-    ```yaml title="<config directory>/www/sidebar-config.yaml"
-    extend_from:
-      - 'colors'
-      - 'titles'
-    extendable_configs:
-      colors:
-        icon_color: 'red'
-        text_color: 'red'
-      titles:
-        title: 'Custom Title'
-        subtitle: 'Custom Subtitle'
-    ```
-  </TabItem>
-  <TabItem value="json" label="JSON">
-    ```json title="<config directory>/www/sidebar-config.json"
-    {
-      "extend_from": [
-        "colors",
-        "titles"
-      ],
-      "extendable_configs": {
-        "colors": {
-          "icon_color": "red",
-          "text_color": "red"
-        },
-        "titles": {
-          "title": "Custom Title",
-          "subtitle": "Custom Subtitle"
-        }
-      }
-    }
-    ```
-  </TabItem>
-</Tabs>
+<ExtendingFromMultipleConfigurationsExample />
 
 As already mentioned, an extendable configuration can extend from other extendable configurations:
 
-<Tabs groupId="config">
-  <TabItem value="yaml" label="YAML" default>
-    ```yaml title="<config directory>/www/sidebar-config.yaml"
-    title: 'Custom Title'
-    extend_from: 'example'
-    extendable_configs:
-      colorful:
-        title_color: 'red'
-        subtitle_color: 'blue'
-      example:
-        subtitle: 'Assistant'
-        // highlight-next-line
-        extend_from: 'colorful'
-    ```
-  </TabItem>
-  <TabItem value="json" label="JSON">
-    ```json title="<config directory>/www/sidebar-config.json"
-    {
-      "title": "Custom Title",
-      "extend_from": "example",
-      "extendable_configs": {
-        "colorful": {
-          "title_color": "red",
-          "subtitle_color": "blue"
-        },
-        "example": {
-          "subtitle": "Assistant",
-          // highlight-next-line
-          "extend_from": "colorful"
-        }
-      }
-    }
-    ```
-  </TabItem>
-</Tabs>
+<ExtendingFromAnotherExtendableConfigurationExample />
 
 The resulted main config will be:
 
-<Tabs groupId="config">
-  <TabItem value="yaml" label="YAML" default>
-    ```yaml title="<config directory>/www/sidebar-config.yaml"
-    title: 'Custom Title'
-    subtitle: 'Assistant'
-    title_color: 'red'
-    subtitle_color: 'blue'
-    ```
-  </TabItem>
-  <TabItem value="json" label="JSON">
-    ```json title="<config directory>/www/sidebar-config.json"
-    {
-      "title": "Custom Title",
-      "subtitle": "Assistant",
-      "title_color": "red",
-      "subtitle_color": "blue"
-    }
-    ```
-  </TabItem>
-</Tabs>
+<ExtendingFromAnotherExtendableConfigurationResultExample />
 
 In the case of [Exceptions](../configuration/exceptions), they can also extend from the main configuration if `base` is used in the `extend_from` option:
 
-<Tabs groupId="config">
-  <TabItem value="yaml" label="YAML" default>
-    ```yaml title="<config directory>/www/sidebar-config.yaml"
-    title: 'Custom Title'
-    extend_from: 'example'
-    extendable_configs:
-      colorful:
-        title_color: 'red'
-        subtitle_color: 'blue'
-      example:
-        subtitle: 'Assistant'
-        extend_from: 'colorful'
-    exceptions:
-      - user:
-        - 'ElChiniNet'
-        order:
-          - item: 'overview'
-            name: 'Dashboard'
-            icon: 'mdi:monitor-dashboard'
-            order: 3
-        // highlight-next-line
-        extend_from: 'base'
-    ```
-  </TabItem>
-  <TabItem value="json" label="JSON">
-    ```json title="<config directory>/www/sidebar-config.json"
-    {
-      "title": "Custom Title",
-      "extend_from": "example",
-      "extendable_configs": {
-        "colorful": {
-          "title_color": "red",
-          "subtitle_color": "blue"
-        },
-        "example": {
-          "subtitle": "Assistant",
-          "extend_from": "colorful"
-        }
-      },
-      "exceptions": [
-        {
-          "user": [
-            "ElChiniNet"
-          ],
-          "order": [
-            {
-              "item": "overview",
-              "name": "Dashboard",
-              "icon": "mdi:monitor-dashboard",
-              "order": 3
-            }
-          ],
-          // highlight-next-line
-          "extend_from": "base"
-        }
-      ]
-    }
-    ```
-  </TabItem>
-</Tabs>
+<ExtendingFromBaseExample />
 
 So, the configuration for the user `ElChiniNet` will be the same previous main config, plus an order with an order-item.
 
 The next example is a more complex one extending from multiple configurations:
 
-<Tabs groupId="config">
-  <TabItem value="yaml" label="YAML" default>
-    ```yaml title="<config directory>/www/sidebar-config.yaml"
-    title: 'My Home'
-    extend_from: 'admin_config'
-    order:
-      - new_item: true
-        item: 'Google'
-        href: 'https://mrdoob.com/projects/chromeexperiments/google-gravity/'
-        icon: 'mdi:earth'
-        target: '_blank'
-        order: 1
-    extendable_configs:
-      multicolor:
-        icon_color: 'red'
-        icon_color_selected: 'blue'
-        icon_color_hover: 'green'
-        text_color: 'red'
-        text_color_selected: 'blue'
-        text_color_hover: 'green'
-      admin_config:
-        order:
-          - new_item: true
-            item: 'Integrations'
-            href: '/config/integrations'
-            icon: 'mdi:puzzle'
-            order: 2
-          - new_item: true
-            item: 'Entities'
-            href: '/config/entities'
-            icon: 'mdi:hexagon-multiple'
-            order: 3
-      user_config:
-        extend_from: 'multicolor'
-        hide_all: true
-        order:
-          - item: 'overview'
-            hide: false
-    exceptions:
-      - is_admin: true
-        extend_from:
-          - 'multicolor'
-          - 'admin_config'
-        order:
-          - item: 'config'
-            bottom: true
-      - user:
-        - 'ElChiniNet'
-        - 'Paulus'
-        etend_from: 'base'
-        title: 'HA'
-      - user:
-        - 'Jim Hawkins'
-        - 'Long John Silver'
-        extend_from: 'user_config'
-        order:
-          - item: 'overview'
-            name: 'Dashboard'
-    ```
-  </TabItem>
-  <TabItem value="json" label="JSON">
-    ```json title="<config directory>/www/sidebar-config.json"
-    {
-      "title": "My Home",
-      "extend_from": "admin_config",
-      "order": [
-        {
-          "new_item": true,
-          "item": "Google",
-          "href": "https://mrdoob.com/projects/chromeexperiments/google-gravity/",
-          "icon": "mdi:earth",
-          "target": "_blank",
-          "order": 1
-        }
-      ],
-      "extendable_configs": {
-        "multicolor": {
-          "icon_color": "red",
-          "icon_color_selected": "blue",
-          "icon_color_hover": "green",
-          "text_color": "red",
-          "text_color_selected": "blue",
-          "text_color_hover": "green"
-        },
-        "admin_config": {
-          "order": [
-            {
-              "new_item": true,
-              "item": "Integrations",
-              "href": "/config/integrations",
-              "icon": "mdi:puzzle",
-              "order": 2
-            },
-            {
-              "new_item": true,
-              "item": "Entities",
-              "href": "/config/entities",
-              "icon": "mdi:hexagon-multiple",
-              "order": 3
-            }
-          ]
-        },
-        "user_config": {
-          "extend_from": "multicolor",
-          "hide_all": true,
-          "order": [
-            {
-              "item": "overview",
-              "hide": false
-            }
-          ]
-        }
-      },
-      "exceptions": [
-        {
-          "is_admin": true,
-          "extend_from": [
-            "multicolor",
-            "admin_config"
-          ],
-          "order": [
-            {
-              "item": "config",
-              "bottom": true
-            }
-          ]
-        },
-        {
-          "user": [
-            "ElChiniNet",
-            "Paulus"
-          ],
-          "etend_from": "base",
-          "title": "HA"
-        },
-        {
-          "user": [
-            "Jim Hawkins",
-            "Long John Silver"
-          ],
-          "extend_from": "user_config",
-          "order": [
-            {
-              "item": "overview",
-              "name": "Dashboard"
-            }
-          ]
-        }
-      ]
-    }
-    ```
-  </TabItem>
-</Tabs>
+<ComplexExample />
 
 :::warning[Important]
 

--- a/docs/docs/05-advanced-configuration-options/_partials/extendable-configurations/_complex-example.mdx
+++ b/docs/docs/05-advanced-configuration-options/_partials/extendable-configurations/_complex-example.mdx
@@ -1,0 +1,156 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs groupId="config">
+  <TabItem value="yaml" label="YAML" default>
+    ```yaml title="<config directory>/www/sidebar-config.yaml"
+    title: 'My Home'
+    extend_from: 'admin_config'
+    order:
+      - new_item: true
+        item: 'Google'
+        href: 'https://mrdoob.com/projects/chromeexperiments/google-gravity/'
+        icon: 'mdi:earth'
+        target: '_blank'
+        order: 1
+    extendable_configs:
+      multicolor:
+        icon_color: 'red'
+        icon_color_selected: 'blue'
+        icon_color_hover: 'green'
+        text_color: 'red'
+        text_color_selected: 'blue'
+        text_color_hover: 'green'
+      admin_config:
+        order:
+          - new_item: true
+            item: 'Integrations'
+            href: '/config/integrations'
+            icon: 'mdi:puzzle'
+            order: 2
+          - new_item: true
+            item: 'Entities'
+            href: '/config/entities'
+            icon: 'mdi:hexagon-multiple'
+            order: 3
+      user_config:
+        extend_from: 'multicolor'
+        hide_all: true
+        order:
+          - item: 'overview'
+            hide: false
+    exceptions:
+      - is_admin: true
+        extend_from:
+          - 'multicolor'
+          - 'admin_config'
+        order:
+          - item: 'config'
+            bottom: true
+      - user:
+        - 'ElChiniNet'
+        - 'Paulus'
+        etend_from: 'base'
+        title: 'HA'
+      - user:
+        - 'Jim Hawkins'
+        - 'Long John Silver'
+        extend_from: 'user_config'
+        order:
+          - item: 'overview'
+            name: 'Dashboard'
+    ```
+  </TabItem>
+  <TabItem value="json" label="JSON">
+    ```json title="<config directory>/www/sidebar-config.json"
+    {
+      "title": "My Home",
+      "extend_from": "admin_config",
+      "order": [
+        {
+          "new_item": true,
+          "item": "Google",
+          "href": "https://mrdoob.com/projects/chromeexperiments/google-gravity/",
+          "icon": "mdi:earth",
+          "target": "_blank",
+          "order": 1
+        }
+      ],
+      "extendable_configs": {
+        "multicolor": {
+          "icon_color": "red",
+          "icon_color_selected": "blue",
+          "icon_color_hover": "green",
+          "text_color": "red",
+          "text_color_selected": "blue",
+          "text_color_hover": "green"
+        },
+        "admin_config": {
+          "order": [
+            {
+              "new_item": true,
+              "item": "Integrations",
+              "href": "/config/integrations",
+              "icon": "mdi:puzzle",
+              "order": 2
+            },
+            {
+              "new_item": true,
+              "item": "Entities",
+              "href": "/config/entities",
+              "icon": "mdi:hexagon-multiple",
+              "order": 3
+            }
+          ]
+        },
+        "user_config": {
+          "extend_from": "multicolor",
+          "hide_all": true,
+          "order": [
+            {
+              "item": "overview",
+              "hide": false
+            }
+          ]
+        }
+      },
+      "exceptions": [
+        {
+          "is_admin": true,
+          "extend_from": [
+            "multicolor",
+            "admin_config"
+          ],
+          "order": [
+            {
+              "item": "config",
+              "bottom": true
+            }
+          ]
+        },
+        {
+          "user": [
+            "ElChiniNet",
+            "Paulus"
+          ],
+          "etend_from": "base",
+          "title": "HA"
+        },
+        {
+          "user": [
+            "Jim Hawkins",
+            "Long John Silver"
+          ],
+          "extend_from": "user_config",
+          "order": [
+            {
+              "item": "overview",
+              "name": "Dashboard"
+            }
+          ]
+        }
+      ]
+    }
+    ```
+  </TabItem>
+</Tabs>

--- a/docs/docs/05-advanced-configuration-options/_partials/extendable-configurations/_extendable-configurations-result.mdx
+++ b/docs/docs/05-advanced-configuration-options/_partials/extendable-configurations/_extendable-configurations-result.mdx
@@ -1,0 +1,58 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs groupId="config">
+  <TabItem value="yaml" label="YAML" default>
+    ```yaml title="<config directory>/www/sidebar-config.yaml"
+    title: 'Custom Title'
+    subtitle: 'Assistant'
+    order:
+      - new_item: true
+        item: 'Google'
+        href: 'https://mrdoob.com/projects/chromeexperiments/google-gravity/'
+        icon: 'mdi:earth'
+        target: '_blank'
+        order: 1
+      - new_item: true
+        item: 'Integrations'
+        href: '/config/integrations'
+        icon: 'mdi:puzzle'
+        order: 2
+      - item: 'overview'
+        name: 'Dashboard'
+        icon: 'mdi:monitor-dashboard'
+        order: 3
+    ```
+  </TabItem>
+  <TabItem value="json" label="JSON">
+    ```json title="<config directory>/www/sidebar-config.json"
+    {
+      "title": "Custom Title",
+      "subtitle": "Assistant",
+      "order": [
+        {
+          "new_item": true,
+          "item": "Google",
+          "href": "https://mrdoob.com/projects/chromeexperiments/google-gravity/",
+          "icon": "mdi:earth",
+          "target": "_blank",
+          "order": 1
+        },
+        {
+          "new_item": true,
+          "item": "Integrations",
+          "href": "/config/integrations",
+          "icon": "mdi:puzzle",
+          "order": 2
+        },
+        {
+          "item": "overview",
+          "name": "Dashboard",
+          "icon": "mdi:monitor-dashboard",
+          "order": 3
+        }
+      ]
+    }
+    ```
+  </TabItem>
+</Tabs>

--- a/docs/docs/05-advanced-configuration-options/_partials/extendable-configurations/_extendable-configurations.mdx
+++ b/docs/docs/05-advanced-configuration-options/_partials/extendable-configurations/_extendable-configurations.mdx
@@ -1,0 +1,79 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs groupId="config">
+  <TabItem value="yaml" label="YAML" default>
+    ```yaml title="<config directory>/www/sidebar-config.yaml"
+    title: 'Custom Title'
+    order:
+      - item: 'overview'
+        name: 'Dashboard'
+        order: 3
+      - new_item: true
+        item: 'Integrations'
+        href: '/config/integrations'
+        icon: 'mdi:puzzle'
+        order: 2
+    // highlight-next-line
+    extend_from: 'example'
+    extendable_configs:
+      example:
+        title: 'My Home'
+        subtitle: 'Assistant'
+        order:
+          - item: 'overview'
+            icon: 'mdi:monitor-dashboard'
+            order: 0
+          - new_item: true
+            item: 'Google'
+            href: 'https://mrdoob.com/projects/chromeexperiments/google-gravity/'
+            icon: 'mdi:earth'
+            target: '_blank'
+            order: 1
+    ```
+  </TabItem>
+  <TabItem value="json" label="JSON">
+    ```json title="<config directory>/www/sidebar-config.json"
+    {
+      "title": "Custom Title",
+      "order": [
+        {
+          "item": "overview",
+          "name": "Dashboard",
+          "order": 3
+        },
+        {
+          "new_item": true,
+          "item": "Integrations",
+          "href": "/config/integrations",
+          "icon": "mdi:puzzle",
+          "order": 2
+        }
+      ],
+      // highlight-next-line
+      "extend_from": "example",
+      "extendable_configs": {
+        "example": {
+          "title": "My Home",
+          "subtitle": "Assistant",
+          "order": [
+            {
+              "item": "overview",
+              "icon": "mdi:monitor-dashboard",
+              "order": 0
+            },
+            {
+              "new_item": true,
+              "item": "Google",
+              "href": "https://mrdoob.com/projects/chromeexperiments/google-gravity/",
+              "icon": "mdi:earth",
+              "target": "_blank",
+              "order": 1
+            }
+          ]
+        }
+      }
+    }
+    ```
+  </TabItem>
+</Tabs>

--- a/docs/docs/05-advanced-configuration-options/_partials/extendable-configurations/_extending-from-another-extendable-configuration-result.mdx
+++ b/docs/docs/05-advanced-configuration-options/_partials/extendable-configurations/_extending-from-another-extendable-configuration-result.mdx
@@ -1,0 +1,23 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs groupId="config">
+  <TabItem value="yaml" label="YAML" default>
+    ```yaml title="<config directory>/www/sidebar-config.yaml"
+    title: 'Custom Title'
+    subtitle: 'Assistant'
+    title_color: 'red'
+    subtitle_color: 'blue'
+    ```
+  </TabItem>
+  <TabItem value="json" label="JSON">
+    ```json title="<config directory>/www/sidebar-config.json"
+    {
+      "title": "Custom Title",
+      "subtitle": "Assistant",
+      "title_color": "red",
+      "subtitle_color": "blue"
+    }
+    ```
+  </TabItem>
+</Tabs>

--- a/docs/docs/05-advanced-configuration-options/_partials/extendable-configurations/_extending-from-another-extendable-configuration.mdx
+++ b/docs/docs/05-advanced-configuration-options/_partials/extendable-configurations/_extending-from-another-extendable-configuration.mdx
@@ -1,0 +1,38 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs groupId="config">
+  <TabItem value="yaml" label="YAML" default>
+    ```yaml title="<config directory>/www/sidebar-config.yaml"
+    title: 'Custom Title'
+    extend_from: 'example'
+    extendable_configs:
+      colorful:
+        title_color: 'red'
+        subtitle_color: 'blue'
+      example:
+        subtitle: 'Assistant'
+        // highlight-next-line
+        extend_from: 'colorful'
+    ```
+  </TabItem>
+  <TabItem value="json" label="JSON">
+    ```json title="<config directory>/www/sidebar-config.json"
+    {
+      "title": "Custom Title",
+      "extend_from": "example",
+      "extendable_configs": {
+        "colorful": {
+          "title_color": "red",
+          "subtitle_color": "blue"
+        },
+        "example": {
+          "subtitle": "Assistant",
+          // highlight-next-line
+          "extend_from": "colorful"
+        }
+      }
+    }
+    ```
+  </TabItem>
+</Tabs>

--- a/docs/docs/05-advanced-configuration-options/_partials/extendable-configurations/_extending-from-base.mdx
+++ b/docs/docs/05-advanced-configuration-options/_partials/extendable-configurations/_extending-from-base.mdx
@@ -1,0 +1,63 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs groupId="config">
+  <TabItem value="yaml" label="YAML" default>
+    ```yaml title="<config directory>/www/sidebar-config.yaml"
+    title: 'Custom Title'
+    extend_from: 'example'
+    extendable_configs:
+      colorful:
+        title_color: 'red'
+        subtitle_color: 'blue'
+      example:
+        subtitle: 'Assistant'
+        extend_from: 'colorful'
+    exceptions:
+      - user:
+        - 'ElChiniNet'
+        order:
+          - item: 'overview'
+            name: 'Dashboard'
+            icon: 'mdi:monitor-dashboard'
+            order: 3
+        // highlight-next-line
+        extend_from: 'base'
+    ```
+  </TabItem>
+  <TabItem value="json" label="JSON">
+    ```json title="<config directory>/www/sidebar-config.json"
+    {
+      "title": "Custom Title",
+      "extend_from": "example",
+      "extendable_configs": {
+        "colorful": {
+          "title_color": "red",
+          "subtitle_color": "blue"
+        },
+        "example": {
+          "subtitle": "Assistant",
+          "extend_from": "colorful"
+        }
+      },
+      "exceptions": [
+        {
+          "user": [
+            "ElChiniNet"
+          ],
+          "order": [
+            {
+              "item": "overview",
+              "name": "Dashboard",
+              "icon": "mdi:monitor-dashboard",
+              "order": 3
+            }
+          ],
+          // highlight-next-line
+          "extend_from": "base"
+        }
+      ]
+    }
+    ```
+  </TabItem>
+</Tabs>

--- a/docs/docs/05-advanced-configuration-options/_partials/extendable-configurations/_extending-from-multiple-configurations.mdx
+++ b/docs/docs/05-advanced-configuration-options/_partials/extendable-configurations/_extending-from-multiple-configurations.mdx
@@ -1,0 +1,39 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs groupId="config">
+  <TabItem value="yaml" label="YAML" default>
+    ```yaml title="<config directory>/www/sidebar-config.yaml"
+    extend_from:
+      - 'colors'
+      - 'titles'
+    extendable_configs:
+      colors:
+        icon_color: 'red'
+        text_color: 'red'
+      titles:
+        title: 'Custom Title'
+        subtitle: 'Custom Subtitle'
+    ```
+  </TabItem>
+  <TabItem value="json" label="JSON">
+    ```json title="<config directory>/www/sidebar-config.json"
+    {
+      "extend_from": [
+        "colors",
+        "titles"
+      ],
+      "extendable_configs": {
+        "colors": {
+          "icon_color": "red",
+          "text_color": "red"
+        },
+        "titles": {
+          "title": "Custom Title",
+          "subtitle": "Custom Subtitle"
+        }
+      }
+    }
+    ```
+  </TabItem>
+</Tabs>

--- a/docs/docs/05-advanced-configuration-options/_partials/javascript-variables/_javascript-variables.mdx
+++ b/docs/docs/05-advanced-configuration-options/_partials/javascript-variables/_javascript-variables.mdx
@@ -1,0 +1,48 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs groupId="config">
+  <TabItem value="yaml" label="YAML" default>
+    ```yaml title="<config directory>/www/sidebar-config.yaml"
+    js_variables:
+      my_string: 'Title'
+      my_number: 100
+      my_boolean: true
+      my_object:
+        prop1: 4
+        prop2: 5
+      my_array:
+        - 'cat'
+        - 'dog'
+        - 'bird'
+    title: |
+      [[[
+        if (my_boolean) {
+          return `${my_string} ${(my_number * my_object.prop1) / my_object.prop2} ${my_array[1]}`;
+        }
+        return 'Home Assistant';
+      ]]]
+    ```
+  </TabItem>
+  <TabItem value="json" label="JSON">
+    ```json title="<config directory>/www/sidebar-config.json"
+    {
+      "js_variables": {
+        "my_string": "Title",
+        "my_number": 100,
+        "my_boolean": true,
+        "my_object": {
+          "prop1": 4,
+          "prop2": 5
+        },
+        "my_array": [
+          "cat",
+          "dog",
+          "bird"
+        ]
+      },
+      "title": "return (my_boolean) ? `${my_string} ${(my_number * my_object.prop1) / my_object.prop2} ${my_array[1]}` : 'Home Assistant';"
+    }
+    ```
+  </TabItem>
+</Tabs>

--- a/docs/docs/05-advanced-configuration-options/_partials/javascript-variables/_reactive-variables-working.mdx
+++ b/docs/docs/05-advanced-configuration-options/_partials/javascript-variables/_reactive-variables-working.mdx
@@ -1,0 +1,75 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs groupId="config">
+  <TabItem value="yaml" label="YAML" default>
+    ```yaml title="<config directory>/www/sidebar-config.yaml"
+    js_variables:
+      my_string: 'ref("Title")'
+      my_number: 'ref(100)'
+      my_boolean: 'ref(true)'
+      my_object: |
+        ref({
+          prop1: 4,
+          prop2: 5
+        })
+      my_array: |
+        ref([
+          'cat',
+          'dog',
+          'bird'
+        ])
+    title: |
+      [[[
+        const my_boolean = ref('my_boolean').value;
+        const my_string = ref('my_string').value;
+        const my_number = ref('my_number').value;
+        const my_object = ref('my_object').value;
+        const my_array = ref('my_array').value;
+        if (my_boolean) {
+          return `${my_string} ${(my_number * my_object.prop1) / my_object.prop2} ${my_array[1]}`;
+        }
+        return 'Home Assistant';
+      ]]]
+    order:
+      - new_item: true
+        item: 'Example'
+        icon: 'mdi:gesture-tap'
+        on_click:
+          action: 'javascript'
+          code: |
+            const my_number = ref('my_number');
+            const my_object = ref('my_object');
+            my_number.value *= 2;
+            my_object.value = {
+                ...my_object.value,
+                prop1: my_object.value.prop1 + 2
+            };
+    ```
+  </TabItem>
+  <TabItem value="json" label="JSON">
+    ```json title="<config directory>/www/sidebar-config.json"
+    {
+      "js_variables": {
+        "my_string": "ref('Title')",
+        "my_number": "ref(100)",
+        "my_boolean": "ref(true)",
+        "my_object": "ref({ prop1: 4, prop2: 5 })",
+        "my_array": "ref(['cat', 'dog', 'bird'])"
+      },
+      "title": "[[[ const my_boolean = ref('my_boolean').value, my_string = ref('my_string').value, my_number = ref('my_number').value, my_object = ref('my_object').value, my_array = ref('my_array').value; return my_boolean ? `${my_string} ${(my_number * my_object.prop1) / my_object.prop2} ${my_array[1]}` : 'Home Assistant' ]]]",
+      "order": [
+        {
+            "new_item": true,
+            "item": "Example",
+            "icon": "mdi:gesture-tap",
+            "on_click": {
+                "action": "javascript",
+                "code": "const my_number = ref('my_number'), my_object = ref('my_object'); my_number.value *= 2; my_object.value = { ...my_object.value, prop1: my_object.value.prop1 + 2 }"
+            }
+        }
+      ]
+    }
+    ```
+  </TabItem>
+</Tabs>

--- a/docs/docs/05-advanced-configuration-options/_partials/javascript-variables/_reactive-variables.mdx
+++ b/docs/docs/05-advanced-configuration-options/_partials/javascript-variables/_reactive-variables.mdx
@@ -1,0 +1,50 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs groupId="config">
+  <TabItem value="yaml" label="YAML" default>
+    ```yaml title="<config directory>/www/sidebar-config.yaml"
+    js_variables:
+      my_string: 'ref("Title")'
+      my_number: 'ref(100)'
+      my_boolean: 'ref(true)'
+      my_object: |
+        ref({
+          prop1: 4,
+          prop2: 5
+        })
+      my_array: |
+        ref([
+          'cat',
+          'dog',
+          'bird'
+        ])
+    title: |
+      [[[
+        const my_boolean = ref('my_boolean').value;
+        const my_string = ref('my_string').value;
+        const my_number = ref('my_number').value;
+        const my_object = ref('my_object').value;
+        const my_array = ref('my_array').value;
+        if (my_boolean) {
+          return `${my_string} ${(my_number * my_object.prop1) / my_object.prop2} ${my_array[1]}`;
+        }
+        return 'Home Assistant';
+      ]]]
+    ```
+  </TabItem>
+  <TabItem value="json" label="JSON">
+    ```json title="<config directory>/www/sidebar-config.json"
+    {
+      "js_variables": {
+        "my_string": "ref('Title')",
+        "my_number": "ref(100)",
+        "my_boolean": "ref(true)",
+        "my_object": "ref({ prop1: 4, prop2: 5 })",
+        "my_array": "ref(['cat', 'dog', 'bird'])"
+      },
+      "title": "[[[ const my_boolean = ref('my_boolean').value, my_string = ref('my_string').value, my_number = ref('my_number').value, my_object = ref('my_object').value, my_array = ref('my_array').value; return my_boolean ? `${my_string} ${(my_number * my_object.prop1) / my_object.prop2} ${my_array[1]}` : 'Home Assistant' ]]]"
+    }
+    ```
+  </TabItem>
+</Tabs>

--- a/docs/docs/05-advanced-configuration-options/_partials/jinja-variables/_jinja-variables.mdx
+++ b/docs/docs/05-advanced-configuration-options/_partials/jinja-variables/_jinja-variables.mdx
@@ -1,0 +1,47 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs groupId="config">
+  <TabItem value="yaml" label="YAML" default>
+    ```yaml title="<config directory>/www/sidebar-config.yaml"
+    jinja_variables:
+      my_string: Title
+      my_number: 100
+      my_boolean: true
+      my_dictionary:
+        prop1: 4
+        prop2: 5
+      my_list:
+        - cat
+        - dog
+        - bird
+      title: |
+        {% if my_boolean %}
+          {{ my_string }} {{ ((my_number * my_dictionary.prop1) / my_dictionary.prop2) | int }} {{ my_list.1 }}
+        {% else %}
+          Home Assistant
+        {% endif %}
+    ```
+  </TabItem>
+  <TabItem value="json" label="JSON">
+    ```json title="<config directory>/www/sidebar-config.json"
+    {
+      "jinja_variables": {
+        "my_string": "Title",
+        "my_number": 100,
+        "my_boolean": true,
+        "my_dictionary": {
+          "prop1": 4,
+          "prop2": 5
+        },
+        "my_list": [
+          "cat",
+          "dog",
+          "bird"
+        ]
+      },
+      "title": "{% if my_boolean %} {{ my_string }} {{ ((my_number * my_dictionary.prop1) / my_dictionary.prop2) | int }} {{ my_list.1 }} {% else %} Home Assistant {% endif %}"
+    }
+    ```
+  </TabItem>
+</Tabs>

--- a/docs/docs/05-advanced-configuration-options/_partials/partials/_with-javascript-templates.mdx
+++ b/docs/docs/05-advanced-configuration-options/_partials/partials/_with-javascript-templates.mdx
@@ -1,0 +1,65 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs groupId="config">
+  <TabItem value="yaml" label="YAML" default>
+    ```yaml title="<config directory>/www/sidebar-config.yaml"
+    js_variables:
+      supervisor_update: 'update.home_assistant_supervisor_update'
+      os_update: 'update.home_assistant_operating_system_update'
+    // highlight-start
+    partials:
+      supervisor_version: |
+        const supervisorVersion = state_attr(supervisor_update, "latest_version");
+      updates: |
+        @partial supervisor_version
+        const osVersion = state_attr(os_update, "latest_version");
+    // highlight-end
+    order:
+      - new_item: true
+        item: 'info'
+        name: |
+          [[[
+            // highlight-next-line
+            @partial updates
+            return `Info ${supervisorVersion}`;
+          ]]]
+        info: |
+          [[[
+            // highlight-next-line
+            @partial updates
+            return `OS ${ osVersion }`;
+          ]]]
+        href: '/config/info'
+        icon: 'mdi:information-outline'
+    ```
+  </TabItem>
+  <TabItem value="json" label="JSON">
+    ```json title="<config directory>/www/sidebar-config.json"
+    {
+      "js_variables": {
+        "supervisor_update": "update.home_assistant_supervisor_update",
+        "os_update": "update.home_assistant_operating_system_update"
+      },
+      // highlight-start
+      "partials": {
+        "supervisor_version": "const supervisorVersion = state_attr(supervisor_update, 'latest_version');",
+        "updates": "@partial supervisor_version const osVersion = state_attr(os_update, 'latest_version');"
+      },
+      // highlight-end
+      "order": [
+        {
+          "new_item": true,
+          "item": "info",
+          // highlight-start
+          "name": "[[[ @partial updates return `Info ${supervisorVersion}`; ]]]",
+          "info": "[[[ @partial updates return `OS ${ osVersion }`; ]]]",
+          // highlight-end
+          "href": "/config/info",
+          "icon": "mdi:information-outline"
+        }
+      ]
+    }
+    ```
+  </TabItem>
+</Tabs>

--- a/docs/docs/05-advanced-configuration-options/_partials/partials/_with-jinja-templates.mdx
+++ b/docs/docs/05-advanced-configuration-options/_partials/partials/_with-jinja-templates.mdx
@@ -1,0 +1,61 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs groupId="config">
+  <TabItem value="yaml" label="YAML" default>
+    ```yaml title="<config directory>/www/sidebar-config.yaml"
+    jinja_variables:
+      supervisor_update: 'update.home_assistant_supervisor_update'
+      os_update: 'update.home_assistant_operating_system_update'
+    // highlight-start
+    partials:
+      supervisor_version: |
+        {% set supervisorVersion = state_attr(supervisor_update, "latest_version") %}
+      updates: |
+        @partial supervisor_version
+        {% set osVersion = state_attr(os_update, "latest_version") %}
+    // highlight-end
+    order:
+      - new_item: true
+        item: 'info'
+        name: |
+          // highlight-next-line
+          @partial updates
+          Info {{ supervisorVersion }}
+        info: |
+          // highlight-next-line
+          @partial updates
+          OS {{ osVersion }}
+        href: '/config/info'
+        icon: 'mdi:information-outline'
+    ```
+  </TabItem>
+  <TabItem value="json" label="JSON">
+    ```json title="<config directory>/www/sidebar-config.json"
+    {
+      "jinja_variables": {
+        "supervisor_update": "update.home_assistant_supervisor_update",
+        "os_update": "update.home_assistant_operating_system_update"
+      },
+      // highlight-start
+      "partials": {
+        "supervisor_version": "{% set supervisorVersion = state_attr(supervisor_update, 'latest_version') %}",
+        "updates": "@partial supervisor_version {% set osVersion = state_attr(os_update, 'latest_version') %}"
+      },
+      // highlight-end
+      "order": [
+        {
+          "new_item": true,
+          "item": "info",
+          // highlight-start
+          "name": "@partial updates Info {{ supervisorVersion }}",
+          "info": "@partial updates OS {{ osVersion }}",
+          // highlight-end
+          "href": "/config/info",
+          "icon": "mdi:information-outline"
+        }
+      ]
+    }
+    ```
+  </TabItem>
+</Tabs>

--- a/docs/docs/_partials/installation/_installation-manual.mdx
+++ b/docs/docs/_partials/installation/_installation-manual.mdx
@@ -1,0 +1,19 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs groupId="config">
+  <TabItem value="yaml" label="If you want to use a YAML configuration" default>
+    ```yaml title="configuration.yaml"
+    frontend:
+      extra_module_url:
+        - /local/custom-sidebar-yaml.js?v1.0.0
+    ```
+  </TabItem>
+  <TabItem value="json" label="If you want to use a JSON configuration">
+    ```yaml title="configuration.yaml"
+    frontend:
+      extra_module_url:
+        - /local/custom-sidebar-json.js?v1.0.0
+    ```
+  </TabItem>
+</Tabs>

--- a/docs/docs/_partials/installation/_installation-trough-hacs.mdx
+++ b/docs/docs/_partials/installation/_installation-trough-hacs.mdx
@@ -1,0 +1,19 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs groupId="config">
+  <TabItem value="yaml" label="If you want to use a YAML configuration" default>
+    ```yaml title="configuration.yaml"
+    frontend:
+      extra_module_url:
+        - /hacsfiles/custom-sidebar/custom-sidebar-yaml.js
+    ```
+  </TabItem>
+  <TabItem value="json" label="If you want to use a JSON configuration">
+    ```yaml title="configuration.yaml"
+    frontend:
+      extra_module_url:
+        - /hacsfiles/custom-sidebar/custom-sidebar-json.js
+    ```
+  </TabItem>
+</Tabs>


### PR DESCRIPTION
This pull request moves the code-blocks examples to markdown partials that can be reused in other markdown files.