### PR TITLE
Change fetch configuration cache option

### DIFF
--- a/src/fetchers/json.ts
+++ b/src/fetchers/json.ts
@@ -11,7 +11,12 @@ export const fetchConfig = async (): Promise<Config> => {
     const errorNotFound = `${NAMESPACE}: JSON config file not found.`;
     const errorSuffix = `Make sure you have valid config in /config/www/${CONFIG_NAME}.json file.`;
     return new Promise<Config>((resolve) => {
-        fetch(`${CONFIG_PATH}.json?hash=${randomId()}`)
+        fetch(
+            `${CONFIG_PATH}.json?hash=${randomId()}`,
+            {
+                cache: 'no-store'
+            }
+        )
             .then((response: Response) => {
                 if (response.ok) {
                     response

--- a/src/fetchers/yaml.ts
+++ b/src/fetchers/yaml.ts
@@ -12,7 +12,12 @@ export const fetchConfig = async (): Promise<Config> => {
     const errorNotFound = `${NAMESPACE}: YAML config file not found.`;
     const errorSuffix = `Make sure you have valid config in /config/www/${CONFIG_NAME}.yaml file.`;
     return new Promise<Config>((resolve) => {
-        fetch(`${CONFIG_PATH}.yaml?hash=${randomId()}`)
+        fetch(
+            `${CONFIG_PATH}.yaml?hash=${randomId()}`,
+            {
+                cache: 'no-store'
+            }
+        )
             .then((response: Response) => {
                 if (response.ok) {
                     response


### PR DESCRIPTION
The configuration is loaded using a random hash as a parameter, but it is still cached somehow in certain scenarios. This pull request changes the [request cache](https://developer.mozilla.org/en-US/docs/Web/API/RequestInit#cache) to `no-store`:

>The browser fetches the resource from the remote server without first looking in the cache, and will not update the cache with the downloaded resource.

Maybe this will solve the multiple issues with configuration cached in certain situations (#310 #287 #183 #131 #130).