### PR TITLE
Skip Coveralls action when the changes are only related to docs

### DIFF
--- a/.github/workflows/hacs.yaml
+++ b/.github/workflows/hacs.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   hacs:
-    name: HACS Action
+    name: Validate
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -57,12 +57,20 @@ jobs:
         run: |
           cd docs
           pnpm build
-      - name: Coveralls
+      - name: Skip Coveralls
         if: ${{ needs.changes.outputs.code != 'true' }}
-        uses: coverallsapp/github-action@master
+        uses: LouisBrunner/checks-action@v2.0.0
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          allow-empty: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: coverage/coveralls
+          conclusion: skipped
+          output: |
+            {
+              "title": "",
+              "summary": "Skipped",
+              "text_description": ""
+            }
+      
 
   test-code:
     name: Test Code


### PR DESCRIPTION
When the changes are only related to docs no code tests run so the Coveralls status check remains in `Expected` stated blocking the pull request. This pull request creates a check with the same Coveralls status expected check with skipped conclusion to avoid this issue.