### PR TITLE
Avoid running HACS job in forks

### DIFF
--- a/.github/workflows/hacs.yaml
+++ b/.github/workflows/hacs.yaml
@@ -11,9 +11,11 @@ on:
 jobs:
   hacs:
     name: Validate
+    if: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
       - name: HACS Action
         uses: hacs/action@main
         with:


### PR DESCRIPTION
This pull request adds a check in the HACS job to avoid it running in pull requests originated from forks.