### PR TITLE
Fix tests failing because a warning coming from Home Assistant

### DIFF
--- a/tests/10 - javascript-templates-returns.spec.ts
+++ b/tests/10 - javascript-templates-returns.spec.ts
@@ -23,7 +23,10 @@ test.describe('title template returns', () => {
         });
 
         page.on('console', message => {
-            if (message.type() === 'warning') {
+            if (
+                message.type() === 'warning' &&
+                !message.text().includes('Vaadin 25') // Home Assistant 2025.4.x is throwing a warning  coming from the Vadding Material Theme
+            ) {
                 expect(message.text()).toContain('ReferenceError: titles is not defined');
             }
         });
@@ -177,7 +180,10 @@ test.describe('name template returns', () => {
         });
 
         page.on('console', message => {
-            if (message.type() === 'warning') {
+            if (
+                message.type() === 'warning' &&
+                !message.text().includes('Vaadin 25') // Home Assistant 2025.4.x is throwing a warning  coming from the Vadding Material Theme
+            ) {
                 expect(message.text()).toContain('ReferenceError: hello is not defined');
             }
         });
@@ -303,7 +309,10 @@ test.describe('notification template returns', () => {
         });
 
         page.on('console', message => {
-            if (message.type() === 'warning') {
+            if (
+                message.type() === 'warning' &&
+                !message.text().includes('Vaadin 25') // Home Assistant 2025.4.x is throwing a warning  coming from the Vadding Material Theme
+            ) {
                 expect(message.text()).toContain('ReferenceError: total is not defined');
             }
         });

--- a/tests/17-debug.spec.ts
+++ b/tests/17-debug.spec.ts
@@ -40,7 +40,7 @@ test('Debug messages shoud not be logged', async ({ page }) => {
 
 });
 
-test('@testing Debug messages shoud be logged', async ({ page }) => {
+test('Debug messages shoud be logged', async ({ page }) => {
 
     const logs: string[] = [];
 


### PR DESCRIPTION
Some tests check if a warning is thrown in the console with a specific text. The next version of Home Assistant (`2025.4.1` which is in beta right now) is throwing a warning:

<img width="501" alt="image" src="https://github.com/user-attachments/assets/50959eff-7503-4883-affe-ecf332d9f7bc" />

This warning is coming from the Vaadin Material Theme:

<img width="800" alt="image" src="https://github.com/user-attachments/assets/b1775c31-f5eb-4d0e-8092-0ce4efeed244" />

In this pull request an extra check is made to avoid checking this warning instead the warning coming from the plugin.