### PR TITLE
Solve vulnerability with estree-util-value-to-estree package

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -50,7 +50,8 @@
       "prismjs@<1.30.0": ">=1.30.0",
       "@babel/runtime-corejs3@<7.26.10": ">=7.26.10",
       "@babel/runtime@<7.26.10": ">=7.26.10",
-      "@babel/helpers@<7.26.10": ">=7.26.10"
+      "@babel/helpers@<7.26.10": ">=7.26.10",
+      "estree-util-value-to-estree@<3.3.3": ">=3.3.3"
     }
   }
 }

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -10,6 +10,7 @@ overrides:
   '@babel/runtime-corejs3@<7.26.10': '>=7.26.10'
   '@babel/runtime@<7.26.10': '>=7.26.10'
   '@babel/helpers@<7.26.10': '>=7.26.10'
+  estree-util-value-to-estree@<3.3.3: '>=3.3.3'
 
 importers:
 
@@ -2378,8 +2379,8 @@ packages:
   estree-util-to-js@2.0.0:
     resolution: {integrity: sha512-WDF+xj5rRWmD5tj6bIqRi6CkLIXbbNQUcxQHzGysQzvHmdYG2G7p/Tf0J0gpxGgkeMZNTIjT/AoSvC9Xehcgdg==}
 
-  estree-util-value-to-estree@3.2.1:
-    resolution: {integrity: sha512-Vt2UOjyPbNQQgT5eJh+K5aATti0OjCIAGc9SgMdOFYbohuifsWclR74l0iZTJwePMgWYdX1hlVS+dedH9XV8kw==}
+  estree-util-value-to-estree@3.3.3:
+    resolution: {integrity: sha512-Db+m1WSD4+mUO7UgMeKkAwdbfNWwIxLt48XF2oFU9emPfXkIu+k5/nlOj313v7wqtAPo0f9REhUvznFrPkG8CQ==}
 
   estree-util-visit@2.0.0:
     resolution: {integrity: sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==}
@@ -6247,7 +6248,7 @@ snapshots:
       '@mdx-js/mdx': 3.1.0(acorn@8.14.0)
       '@slorber/remark-comment': 1.0.0
       escape-html: 1.0.3
-      estree-util-value-to-estree: 3.2.1
+      estree-util-value-to-estree: 3.3.3
       file-loader: 6.2.0(webpack@5.97.1)
       fs-extra: 11.3.0
       image-size: 1.2.1
@@ -8232,7 +8233,7 @@ snapshots:
       astring: 1.9.0
       source-map: 0.7.4
 
-  estree-util-value-to-estree@3.2.1:
+  estree-util-value-to-estree@3.3.3:
     dependencies:
       '@types/estree': 1.0.6
 


### PR DESCRIPTION
This pull request solves a vulnerability related to the `estree-util-value-to-estree` package through `pnpm` overrides.

<img width="1387" alt="image" src="https://github.com/user-attachments/assets/de155296-0dc4-4d83-979f-6d6aaa29e5a7" />
