### PR TITLE
Update Ubuntu version in Home Assistant Beta tests

### DIFF
--- a/.github/workflows/ha-beta-tests.yaml
+++ b/.github/workflows/ha-beta-tests.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:      
   beta-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
This pull request updates the Ubuntu version in Home Assistant beta tests.