### PR TITLE
Solve vulnerability in http-proxy-middleware through pnpm overrides

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -51,7 +51,8 @@
       "@babel/runtime-corejs3@<7.26.10": ">=7.26.10",
       "@babel/runtime@<7.26.10": ">=7.26.10",
       "@babel/helpers@<7.26.10": ">=7.26.10",
-      "estree-util-value-to-estree@<3.3.3": ">=3.3.3"
+      "estree-util-value-to-estree@<3.3.3": ">=3.3.3",
+      "http-proxy-middleware@<2.0.9": "2.0.9"
     }
   }
 }

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -11,6 +11,7 @@ overrides:
   '@babel/runtime@<7.26.10': '>=7.26.10'
   '@babel/helpers@<7.26.10': '>=7.26.10'
   estree-util-value-to-estree@<3.3.3: '>=3.3.3'
+  http-proxy-middleware@<2.0.9: 2.0.9
 
 importers:
 
@@ -2759,8 +2760,8 @@ packages:
   http-parser-js@0.5.9:
     resolution: {integrity: sha512-n1XsPy3rXVxlqxVioEWdC+0+M+SQw0DpJynwtOPo1X+ZlvdzTLtDBIJJlDQTnwZIFJrZSzSGmIOUdP8tu+SgLw==}
 
-  http-proxy-middleware@2.0.7:
-    resolution: {integrity: sha512-fgVY8AV7qU7z/MmXJ/rxwbrtQH4jBQ9m7kp3llF0liB7glmFeVZFBepQb32T3y8n8k2+AEYuMPCpinYW+/CuRA==}
+  http-proxy-middleware@2.0.9:
+    resolution: {integrity: sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
       '@types/express': ^4.17.13
@@ -8760,7 +8761,7 @@ snapshots:
 
   http-parser-js@0.5.9: {}
 
-  http-proxy-middleware@2.0.7(@types/express@4.17.21):
+  http-proxy-middleware@2.0.9(@types/express@4.17.21):
     dependencies:
       '@types/http-proxy': 1.17.15
       http-proxy: 1.18.1
@@ -11224,7 +11225,7 @@ snapshots:
       express: 4.21.2
       graceful-fs: 4.2.11
       html-entities: 2.5.2
-      http-proxy-middleware: 2.0.7(@types/express@4.17.21)
+      http-proxy-middleware: 2.0.9(@types/express@4.17.21)
       ipaddr.js: 2.2.0
       launch-editor: 2.9.1
       open: 8.4.2


### PR DESCRIPTION
This merge request solves two vulnerabilities in `http-proxy-middleware` through `pnpm` overrides.

<img width="1291" alt="image" src="https://github.com/user-attachments/assets/5458433c-f84e-402e-adbe-8622b7ea8457" />

<img width="1281" alt="image" src="https://github.com/user-attachments/assets/077cb5d0-049e-4eca-9dae-423a1e73a508" />
