### PR TITLE
Remove pnpm overrides

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -43,16 +43,5 @@
   },
   "engines": {
     "node": ">=18.0"
-  },
-  "pnpm": {
-    "overrides": {
-      "image-size@<1.2.1": "^1.2.1",
-      "prismjs@<1.30.0": ">=1.30.0",
-      "@babel/runtime-corejs3@<7.26.10": ">=7.26.10",
-      "@babel/runtime@<7.26.10": ">=7.26.10",
-      "@babel/helpers@<7.26.10": ">=7.26.10",
-      "estree-util-value-to-estree@<3.3.3": ">=3.3.3",
-      "http-proxy-middleware@<2.0.9": "2.0.9"
-    }
   }
 }

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -4,15 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  image-size@<1.2.1: ^1.2.1
-  prismjs@<1.30.0: '>=1.30.0'
-  '@babel/runtime-corejs3@<7.26.10': '>=7.26.10'
-  '@babel/runtime@<7.26.10': '>=7.26.10'
-  '@babel/helpers@<7.26.10': '>=7.26.10'
-  estree-util-value-to-estree@<3.3.3: '>=3.3.3'
-  http-proxy-middleware@<2.0.9: 2.0.9
-
 importers:
 
   .:

--- a/package.json
+++ b/package.json
@@ -56,10 +56,5 @@
     "home-assistant-query-selector": "^4.3.0",
     "home-assistant-styles-manager": "^3.1.0",
     "js-yaml": "^4.1.0"
-  },
-  "pnpm": {
-    "overrides": {
-      "@babel/helpers@<7.26.10": ">=7.26.10"
-    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,9 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  '@babel/helpers@<7.26.10': '>=7.26.10'
-
 importers:
 
   .:


### PR DESCRIPTION
This pull request removes `pnpm` overrides because the transitive vulnerable packages have been updated already in the dependent packages.