### PR TITLE
Add a warning about the required versions depending on Home Assistant version

### DIFF
--- a/docs/docs/02-installation.mdx
+++ b/docs/docs/02-installation.mdx
@@ -7,6 +7,12 @@ import InstallationManualExample from '@site/docs/_partials/02-installation/_ins
 
 # Installation
 
+:::warning[Important]
+
+If you have `Home Assistant` `2025.5.0` or greater installed, the minimum compatible version that you can install is `Custom Sidebar` `v10.0.0`. If you are in a lower version of `Home Assistant`, the latest compatible version that you can install is `v9.4.1`.
+
+:::
+
 You can install the plugin manually or through [HACS], not both. **If you install the plugin using the two installations methods you could have issues or errors**.
 
 ### Through HACS (recommended)


### PR DESCRIPTION
This pull request adds a warning stating which `Custom Sidebar` version one can install depending on the `Home Assistant` version.