### PR TITLE
Add one entry to the tip of the main configuration options

### DIFF
--- a/docs/docs/03-configuration/02-main-configuration-options.mdx
+++ b/docs/docs/03-configuration/02-main-configuration-options.mdx
@@ -50,7 +50,7 @@ These options are intended to change the functionality of the sidebar and to cha
 | Property                  | Type    | Required  | Description |
 | ------------------------- | ------- | --------- | ----------- |
 | item                      | String  | yes       | This is a string that will be used to match each sidebar item by its text or its `href`. If the `exact` property is not set, it is case insensitive and it can be a substring such as `developer` instead of `Developer Tools` or `KITCHEN` instead of `kitchen-lights` |
-| match                     | String  | no        | This property will define which string will be used to match the `item` property. It has two possible values "text" (default) to match the text content of the element, or "href" to match the `href` attribute of the element |
+| match<sup>\*\*</sup>      | String  | no        | This property will define which string will be used to match the `item` property. It has two possible values "text" (default) to match the text content of the element, or "href" to match the `href` attribute of the element |
 | exact                     | Boolean | no        | Specifies whether the `item` string match should be an exact match (`true`) or not (`false`) |
 | order                     | Number  | no        | Sets the order of the sidebar item |
 | hide<sup>\*</sup>         | Boolean or String | no | Setting this property to `true` will hide the sidebar item and if the property `hide_all` from the main configuration is `true`, setting this property as `false` will avoid hiding the item |
@@ -69,6 +69,8 @@ These options are intended to change the functionality of the sidebar and to cha
 :::tip
 
 \* These options allow [JavaScript](../templates/javascript-templates) or [Jinja](../templates/jinja-templates) templates.
+
+\*\* If you match by `href` and you are not sure what is the specific `href` of an item, add `cs_debug` parameter to the URL and reload your `Home Assistant` instance (e.g. `http:your-home-assistant-domain:8123?cs_debug`). You will see different debug messages in the browser's console. Open the one that says `custom-sidebar debug: Native sidebar items` and you can see a table with each sidebar item, its text and its respective `href`.
 
 :::
 


### PR DESCRIPTION
This pull request modifies the documentation adding a tip about adding the `cs_debug` parameter to the URL to get a table with the texts and `hrefs` of each sidebar item ([pull request](https://github.com/elchininet/custom-sidebar/pull/416)).