### PR TITLE
Change troubleshooting section of clear App cache

### DIFF
--- a/docs/docs/08-troubleshooting/02-issues-with-the-companion-app.mdx
+++ b/docs/docs/08-troubleshooting/02-issues-with-the-companion-app.mdx
@@ -20,18 +20,8 @@ Home Assistant has a strong caching system. If you notice that the customisation
 
 ## Companion App Android version
 
-Unfortunately, there is no a native button to clean the WebView cache in Android. Until [this](https://github.com/home-assistant/android/issues/2460) is not resolved, alternative methods will be needed.
-
-The easiest way to clean the WebView cache is to log-out from the App and log-in again, but this is a hassle because you will need to reconfigure everything again. The safest way is to follow these steps:
-
-1. Go to `Settings`
-2. Go to `Companion App > Debug > WebView Remote Debug` and activate it
-3. Set up [Chrome Remote Debugging]
-4. Open `chrome://inspect/#devices` in Chrome browser
-5. Inspect the WebView relative to Home Assistant
-6. Go to `Application` and click on `Storage`
-7. Uncheck `Local and session storage` and `Cookies`
-8. Click on `Clear site data`
-9. Close the App and open it again and check if the customisations are applied
-
-[Chrome Remote Debugging]: https://developer.chrome.com/docs/devtools/remote-debugging
+1. Go to the sidebar and click on `Settings`
+2. Scroll down until you see `Companion app` item and click on it
+3. Scroll down until you see `Troubleshooting` item and click on it
+4. Click on `Reset frontend cache`
+5. Close the App and open it again and check if the customisations are applied


### PR DESCRIPTION
This pull request changes the instructions about how to clean cache in the `Android` version of the `Companion App` because [this feature](https://github.com/home-assistant/android/pull/5119) has been already released in the `Android` app.