### PR TITLE
Fix tests on Home Assistant 2025.6.x

### DIFF
--- a/tests/13 - interactions.spec.ts
+++ b/tests/13 - interactions.spec.ts
@@ -258,8 +258,10 @@ test('By default it should be possible to edit the sidebar', async ({ page }) =>
 
     await page.locator(SELECTORS.TITLE).click({ delay: 1000 });
 
-    await expect(page.locator(SELECTORS.TITLE)).not.toBeVisible();
-    await expect(page.locator(SELECTORS.SIDEBAR_EDIT_BUTTON)).toBeVisible();
+    await expect(
+        page.locator(SELECTORS.SIDEBAR_EDIT_BUTTON) // Home Assistant < 2025.6.x
+            .or(page.locator(SELECTORS.SIDEBAR_EDIT_MODAL)) // Home Assistant >= 2025.6.x
+    ).toBeVisible();
 
     await page.goto('/profile');
 
@@ -277,8 +279,10 @@ test('If sidebar_editable is set to true it should be possible to edit the sideb
 
     await page.locator(SELECTORS.TITLE).click({ delay: 1000 });
 
-    await expect(page.locator(SELECTORS.TITLE)).not.toBeVisible();
-    await expect(page.locator(SELECTORS.SIDEBAR_EDIT_BUTTON)).toBeVisible();
+    await expect(
+        page.locator(SELECTORS.SIDEBAR_EDIT_BUTTON) // Home Assistant < 2025.6.x
+            .or(page.locator(SELECTORS.SIDEBAR_EDIT_MODAL)) // Home Assistant >= 2025.6.x
+    ).toBeVisible();
 
     await page.goto('/profile');
 

--- a/tests/constants.ts
+++ b/tests/constants.ts
@@ -22,7 +22,8 @@ export const SELECTORS = {
     MENU: '.menu',
     TITLE: '.menu .title',
     SIDEBAR_HA_ICON_BUTTON: '.menu ha-icon-button',
-    SIDEBAR_EDIT_BUTTON: '.menu mwc-button',
+    SIDEBAR_EDIT_BUTTON: '.menu mwc-button', // Home Assistant < 2025.6.x
+    SIDEBAR_EDIT_MODAL: 'dialog-edit-sidebar span[title="Edit sidebar"]', // Home Assistant >= 2025.6.x
     PROFILE_EDIT_BUTTON: '.content > ha-card ha-settings-row > mwc-button',
     PROFILE_HIDE_SIDEBAR: '.content > ha-card ha-force-narrow-row ha-settings-row > ha-switch',
     NOTIFICATIONS: 'ha-md-list-item.notifications',


### PR DESCRIPTION
This pull request makes the tests compatible with `Home Assistant 2025.6.x` in which the way of editing the sidebar items have changed.