### PR TITLE
Add a statement to the important notes of the HACS installation method

### DIFF
--- a/docs/docs/02-installation.mdx
+++ b/docs/docs/02-installation.mdx
@@ -36,7 +36,7 @@ If you have not disabled the [My Home Assistant] integration, just click on [thi
 
 :::warning[Important]
 
-1. Do not get creative with the path of the plugin, use the provided one. If you have `HACS` installed [the hacsfiles custom path](https://www.hacs.xyz/docs/use/repositories/type/dashboard/#custom-features-for-files-stored-under-hacsfiles) will be there even if you cannot see it in your filesystem.
+1. Do not get creative with the path of the plugin, use the provided one. If you have `HACS` installed [the hacsfiles custom path](https://www.hacs.xyz/docs/use/repositories/type/dashboard/#custom-features-for-files-stored-under-hacsfiles) will be there even if you cannot see it in your filesystem. If the previous statetement is not clear enough: Do not use a path using your `config` or `www` directories because it will not work.
 2. Using Dashboard/lovelace resources in the GUI is not the same as extra_module_url
 3. Do not forget to restart Home Assistant.
 


### PR DESCRIPTION
[There are still some users](https://github.com/elchininet/custom-sidebar/issues/446) that try to use the `config` or `www` folders in their paths inside `extra_module_url`. So, adding more clarity to that important note.