### PR TITLE
Prepare some tests for Home Assistant 2026.1.x

### DIFF
--- a/tests/02 - basic-options.spec.ts
+++ b/tests/02 - basic-options.spec.ts
@@ -818,7 +818,16 @@ test.describe('on_click property', () => {
             }
         );
 
-        const dialog = page.locator('dialog-restart ha-dialog-header');
+        const dialog = page.locator(SELECTORS.RESTART_RIALOG)
+            // Remove when Home Assistant 2026.1.x is released
+            .or(page.locator(SELECTORS.RESTART_RIALOG_OLD));
+        const dialogTitle = page.locator(SELECTORS.RESTART_RIALOG_TITLE)
+            // Remove when Home Assistant 2026.1.x is released
+            .or(page.locator(SELECTORS.RESTART_RIALOG_TITLE_OLD));
+        const dialogCloseButton = page.locator(SELECTORS.RESTART_DIALOG_CLOSE_BUTTON)
+            // Remove when Home Assistant 2026.1.x is released
+            .or(page.locator(SELECTORS.RESTART_DIALOG_CLOSE_BUTTON_OLD))
+            .first();
         const title = 'Restart Home Assistant';
 
         await navigateHome(page);
@@ -826,18 +835,18 @@ test.describe('on_click property', () => {
         // It should load the dialog
         await getSidebarItem(page, '#').click();
 
-        await expect(dialog.locator('span[slot="title"]')).toContainText(title);
+        await expect(dialogTitle).toContainText(title);
 
-        await dialog.locator('ha-icon-button').click();
+        await dialogCloseButton.click();
 
         await expect(dialog).not.toBeVisible();
 
         // It should reuse the dialog already registered in customComponents
         await getSidebarItem(page, '#').click();
 
-        await expect(dialog.locator('span[slot="title"]')).toContainText(title);
+        await expect(dialogTitle).toContainText(title);
 
-        await dialog.locator('ha-icon-button').click();
+        await dialogCloseButton.click();
 
         await expect(dialog).not.toBeVisible();
 

--- a/tests/10 - javascript-templates-methods.spec.ts
+++ b/tests/10 - javascript-templates-methods.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from 'playwright-test-coverage';
-import { CONFIG_FILES } from './constants';
+import { CONFIG_FILES, SELECTORS } from './constants';
 import { haConfigRequest } from './ha-services';
 import {
     fulfillJson,
@@ -281,23 +281,32 @@ test.describe('methods in JavaScript templates', () => {
 
         await navigateHome(page);
 
-        await getSidebarItem(page, '#').click();
-
-        const dialog = page.locator('dialog-restart ha-dialog-header');
+        const dialog = page.locator(SELECTORS.RESTART_RIALOG)
+            // Remove when Home Assistant 2026.1.x is released
+            .or(page.locator(SELECTORS.RESTART_RIALOG_OLD));
+        const dialogTitle = page.locator(SELECTORS.RESTART_RIALOG_TITLE)
+            // Remove when Home Assistant 2026.1.x is released
+            .or(page.locator(SELECTORS.RESTART_RIALOG_TITLE_OLD));
+        const dialogCloseButton = page.locator(SELECTORS.RESTART_DIALOG_CLOSE_BUTTON)
+            // Remove when Home Assistant 2026.1.x is released
+            .or(page.locator(SELECTORS.RESTART_DIALOG_CLOSE_BUTTON_OLD))
+            .first();
         const title = 'Restart Home Assistant';
 
-        await expect(dialog.locator('span[slot="title"]')).toContainText(title);
+        await getSidebarItem(page, '#').click();
 
-        await dialog.locator('ha-icon-button').click();
+        await expect(dialogTitle).toContainText(title);
+
+        await dialogCloseButton.click();
 
         await expect(dialog).not.toBeVisible();
 
         // It should reuse the dialog already registered in customComponents
         await getSidebarItem(page, '#').click();
 
-        await expect(dialog.locator('span[slot="title"]')).toContainText(title);
+        await expect(dialogTitle).toContainText(title);
 
-        await dialog.locator('ha-icon-button').click();
+        await dialogCloseButton.click();
 
         await expect(dialog).not.toBeVisible();
 

--- a/tests/13 - interactions.spec.ts
+++ b/tests/13 - interactions.spec.ts
@@ -509,7 +509,11 @@ test('by default it should be possible to edit the sidebar', async ({ page }) =>
 
     await page.locator(SELECTORS.TITLE).click({ delay: 1000 });
 
-    await expect(page.locator(SELECTORS.SIDEBAR_EDIT_MODAL)).toBeVisible();
+    await expect(
+        page.locator(SELECTORS.SIDEBAR_EDIT_MODAL)
+            // Remove when Home Assistant 2026.1.x is released
+            .or(page.locator(SELECTORS.SIDEBAR_EDIT_MODAL_OLD))
+    ).toBeVisible();
 
     await navigateToProfile(page);
 
@@ -527,7 +531,11 @@ test('if sidebar_editable is set to true it should be possible to edit the sideb
 
     await page.locator(SELECTORS.TITLE).click({ delay: 1000 });
 
-    await expect(page.locator(SELECTORS.SIDEBAR_EDIT_MODAL)).toBeVisible();
+    await expect(
+        page.locator(SELECTORS.SIDEBAR_EDIT_MODAL)
+            // Remove when Home Assistant 2026.1.x is released
+            .or(page.locator(SELECTORS.SIDEBAR_EDIT_MODAL_OLD))
+    ).toBeVisible();
 
     await navigateToProfile(page);
 

--- a/tests/constants.ts
+++ b/tests/constants.ts
@@ -23,7 +23,9 @@ export const SELECTORS = {
     MENU: '.menu',
     TITLE: '.menu .title',
     SIDEBAR_HA_ICON_BUTTON: '.menu ha-icon-button',
-    SIDEBAR_EDIT_MODAL: 'dialog-edit-sidebar span[title="Edit sidebar"]',
+    // Remove when Home Assistant 2026.1.x is released
+    SIDEBAR_EDIT_MODAL_OLD: 'dialog-edit-sidebar span[title="Edit sidebar"]',
+    SIDEBAR_EDIT_MODAL: 'dialog-edit-sidebar ha-wa-dialog[header-title="Edit sidebar"] ha-dialog-header',
     PROFILE_EDIT_BUTTON: '.content > ha-card ha-settings-row > ha-button',
     PROFILE_HIDE_SIDEBAR: '.content > ha-card ha-force-narrow-row ha-settings-row > ha-switch',
     NOTIFICATIONS: 'ha-md-list-item.notifications',
@@ -41,7 +43,15 @@ export const SELECTORS = {
     HA_ICON: 'ha-icon',
     PANEL_CONFIG: 'ha-panel-config',
     ENTRY_CONTAINER: '.entry-container',
-    HA_LOGBOOK: 'ha-logbook'
+    HA_LOGBOOK: 'ha-logbook',
+    // Remove when Home Assistant 2026.1.x is released
+    RESTART_RIALOG_OLD: 'dialog-restart ha-dialog-header',
+    RESTART_RIALOG_TITLE_OLD: 'dialog-restart ha-dialog-header span[slot="title"]',
+    RESTART_DIALOG_CLOSE_BUTTON_OLD: 'dialog-restart ha-dialog-header ha-icon-button',
+    // End remove when Home Assistant 2026.1.x is released
+    RESTART_RIALOG: 'dialog-restart ha-adaptive-dialog .content',
+    RESTART_RIALOG_TITLE: 'dialog-restart ha-dialog-header span[slot="title"]',
+    RESTART_DIALOG_CLOSE_BUTTON: 'dialog-restart ha-adaptive-dialog slot[slot="headerNavigationIcon"] ha-icon-button'
 };
 
 export const ATTRIBUTES = {


### PR DESCRIPTION
Some Nightly Beta Tests are failing because some changes that are being introduced in Home Assistant `2026.1.x`. This pull request makes the new tests to pass maintaining compatibility with the current tests. When the Docker image is updates to the `2026.1.x`, the workaround to make the tests pass with the current and the next version of Home Assistant can be removed.