### PR TITLE
Give test workflow permissions to write on checks

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -34,6 +34,9 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.docs == 'true' }}
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      checks: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
This pull request adds `write` permission to `checks` in the `test-docs` job to allow dependabot pull request to be able to run the `LouisBrunner/checks-action` which needs this permission if the user is not a member of the repository.