### PR TITLE
Remove tests compatibility with Home Assistant < 2026.1.1

### DIFF
--- a/tests/02 - basic-options.spec.ts
+++ b/tests/02 - basic-options.spec.ts
@@ -818,18 +818,9 @@ test.describe('on_click property', () => {
             }
         );
 
-        const dialog = page.locator(SELECTORS.RESTART_RIALOG)
-            // Remove when Home Assistant 2026.1.x is released
-            .or(page.locator(SELECTORS.RESTART_RIALOG_OLD))
-            .first();
-        const dialogTitle = page.locator(SELECTORS.RESTART_RIALOG_TITLE)
-            // Remove when Home Assistant 2026.1.x is released
-            .or(page.locator(SELECTORS.RESTART_RIALOG_TITLE_OLD))
-            .first();
-        const dialogCloseButton = page.locator(SELECTORS.RESTART_DIALOG_CLOSE_BUTTON)
-            // Remove when Home Assistant 2026.1.x is released
-            .or(page.locator(SELECTORS.RESTART_DIALOG_CLOSE_BUTTON_OLD))
-            .first();
+        const dialog = page.locator(SELECTORS.RESTART_RIALOG);
+        const dialogTitle = page.locator(SELECTORS.RESTART_RIALOG_TITLE);
+        const dialogCloseButton = page.locator(SELECTORS.RESTART_DIALOG_CLOSE_BUTTON);
         const title = 'Restart Home Assistant';
 
         await navigateHome(page);

--- a/tests/10 - javascript-templates-methods.spec.ts
+++ b/tests/10 - javascript-templates-methods.spec.ts
@@ -281,18 +281,9 @@ test.describe('methods in JavaScript templates', () => {
 
         await navigateHome(page);
 
-        const dialog = page.locator(SELECTORS.RESTART_RIALOG)
-            // Remove when Home Assistant 2026.1.x is released
-            .or(page.locator(SELECTORS.RESTART_RIALOG_OLD))
-            .first();
-        const dialogTitle = page.locator(SELECTORS.RESTART_RIALOG_TITLE)
-            // Remove when Home Assistant 2026.1.x is released
-            .or(page.locator(SELECTORS.RESTART_RIALOG_TITLE_OLD))
-            .first();
-        const dialogCloseButton = page.locator(SELECTORS.RESTART_DIALOG_CLOSE_BUTTON)
-            // Remove when Home Assistant 2026.1.x is released
-            .or(page.locator(SELECTORS.RESTART_DIALOG_CLOSE_BUTTON_OLD))
-            .first();
+        const dialog = page.locator(SELECTORS.RESTART_RIALOG);
+        const dialogTitle = page.locator(SELECTORS.RESTART_RIALOG_TITLE);
+        const dialogCloseButton = page.locator(SELECTORS.RESTART_DIALOG_CLOSE_BUTTON);
         const title = 'Restart Home Assistant';
 
         await getSidebarItem(page, '#').click();

--- a/tests/13 - interactions.spec.ts
+++ b/tests/13 - interactions.spec.ts
@@ -509,11 +509,7 @@ test('by default it should be possible to edit the sidebar', async ({ page }) =>
 
     await page.locator(SELECTORS.TITLE).click({ delay: 1000 });
 
-    await expect(
-        page.locator(SELECTORS.SIDEBAR_EDIT_MODAL)
-            // Remove when Home Assistant 2026.1.x is released
-            .or(page.locator(SELECTORS.SIDEBAR_EDIT_MODAL_OLD))
-    ).toBeVisible();
+    await expect(page.locator(SELECTORS.SIDEBAR_EDIT_MODAL)).toBeVisible();
 
     await navigateToProfile(page);
 
@@ -531,11 +527,7 @@ test('if sidebar_editable is set to true it should be possible to edit the sideb
 
     await page.locator(SELECTORS.TITLE).click({ delay: 1000 });
 
-    await expect(
-        page.locator(SELECTORS.SIDEBAR_EDIT_MODAL)
-            // Remove when Home Assistant 2026.1.x is released
-            .or(page.locator(SELECTORS.SIDEBAR_EDIT_MODAL_OLD))
-    ).toBeVisible();
+    await expect(page.locator(SELECTORS.SIDEBAR_EDIT_MODAL)).toBeVisible();
 
     await navigateToProfile(page);
 

--- a/tests/constants.ts
+++ b/tests/constants.ts
@@ -23,8 +23,6 @@ export const SELECTORS = {
     MENU: '.menu',
     TITLE: '.menu .title',
     SIDEBAR_HA_ICON_BUTTON: '.menu ha-icon-button',
-    // Remove when Home Assistant 2026.1.x is released
-    SIDEBAR_EDIT_MODAL_OLD: 'dialog-edit-sidebar span[title="Edit sidebar"]',
     SIDEBAR_EDIT_MODAL: 'dialog-edit-sidebar ha-wa-dialog[header-title="Edit sidebar"] ha-dialog-header',
     PROFILE_EDIT_BUTTON: '.content > ha-card ha-settings-row > ha-button',
     PROFILE_HIDE_SIDEBAR: '.content > ha-card ha-force-narrow-row ha-settings-row > ha-switch',
@@ -44,11 +42,6 @@ export const SELECTORS = {
     PANEL_CONFIG: 'ha-panel-config',
     ENTRY_CONTAINER: '.entry-container',
     HA_LOGBOOK: 'ha-logbook',
-    // Remove when Home Assistant 2026.1.x is released
-    RESTART_RIALOG_OLD: 'dialog-restart ha-dialog-header',
-    RESTART_RIALOG_TITLE_OLD: 'dialog-restart ha-dialog-header span[slot="title"]',
-    RESTART_DIALOG_CLOSE_BUTTON_OLD: 'dialog-restart ha-dialog-header ha-icon-button',
-    // End remove when Home Assistant 2026.1.x is released
     RESTART_RIALOG: 'dialog-restart ha-adaptive-dialog .content',
     RESTART_RIALOG_TITLE: 'dialog-restart ha-dialog-header span[slot="title"]',
     RESTART_DIALOG_CLOSE_BUTTON: 'dialog-restart ha-adaptive-dialog slot[slot="headerNavigationIcon"] ha-icon-button'


### PR DESCRIPTION
In [a previous pull request](https://github.com/elchininet/custom-sidebar/pull/528) the tests were prepared for Home Assistant `2026.1.1` making them compatible with old versions through a hack. Home Assistant [has been already updated to 2026.1.1](https://github.com/elchininet/custom-sidebar/pull/538) so the hacks can be removed.