### PR TITLE
Fixing build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -72,7 +72,6 @@ jobs:
         with:
           files: |
             dist/custom-sidebar.js
-            dist/custom-sidebar-json.js
-            dist/custom-sidebar-yaml.js
+            dist/custom-sidebar-plugin.js
           body: |
             ${{ steps.build_changelog.outputs.changelog }}


### PR DESCRIPTION
This pull request fixes the build workflow that was trying to use the old `yaml` and `json` bundles instead of the new `plugin` one.