### PR TITLE
Git ignoreDeprecations to the tsconfig of Docusaurus

### DIFF
--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -2,7 +2,8 @@
   // This file is not used in compilation. It is here just for a nice editor experience.
   "extends": "@docusaurus/tsconfig",
   "compilerOptions": {
-    "baseUrl": "."
+    "baseUrl": ".",
+    "ignoreDeprecations": "6.0"
   },
   "exclude": [".docusaurus", "build"]
 }


### PR DESCRIPTION
This pull request adds the `ignoreDeprecations` property to the `compilerOptions` of the `tsconfig.json` of Docusaurus to avoid TypeScript errors. This file is not use to compile but just for having a nice editor experience and the error provoked by the deprecated `baseUrl` was appearing all the time.