### PR TITLE
Fix wrong URL in the documentation

### DIFF
--- a/docs/docs/03-configuration/02-main-configuration-options.mdx
+++ b/docs/docs/03-configuration/02-main-configuration-options.mdx
@@ -74,7 +74,7 @@ These options are intended to change the functionality of the sidebar and to cha
 
 \* These options allow [JavaScript](../templates/javascript-templates) or [Jinja](../templates/jinja-templates) templates.
 
-\*\* If you match by `href` and you are not sure what is the specific `href` of an item, add `cs_debug` parameter to the URL and reload your `Home Assistant` instance (e.g. `http:your-home-assistant-domain:8123?cs_debug`). You will see different debug messages in the browser's console. Open the one that says `custom-sidebar debug: Native sidebar items` and you can see a table with each sidebar item, its text and its respective `href`.
+\*\* If you match by `href` and you are not sure what is the specific `href` of an item, add `cs_debug` parameter to the URL and reload your `Home Assistant` instance (e.g. `http://your-home-assistant-domain:8123?cs_debug`). You will see different debug messages in the browser's console. Open the one that says `custom-sidebar debug: Native sidebar items` and you can see a table with each sidebar item, its text and its respective `href`.
 
 :::
 


### PR DESCRIPTION
This pull request fixes a wrong URL in the documentation.