### PR TITLE
Move the expanded attributes check to a utility function

### DIFF
--- a/tests/02 - basic-options.spec.ts
+++ b/tests/02 - basic-options.spec.ts
@@ -408,7 +408,23 @@ test.beforeEach(noCacheRoute);
     test(`should set sidebar width.hidden and sidebar.extended and keep them when the sidebar is not extended ${titleSuffix}`, async ({ page }) => {
 
         const desktopViewportSizes = { width: 1280, height: 720 };
-        const sidebar = page.locator(SELECTORS.HA_SIDEBAR);
+
+        const checkExpanded = async (hasAttribute: boolean) => {
+            return await page.locator(SELECTORS.HA_SIDEBAR).evaluate((sidebarElement: HTMLElement, hasAttribute: boolean) => {
+                return new Promise<void>((resolve) => {
+                    const check = () => {
+                        setTimeout(() => {
+                            if (sidebarElement.hasAttribute('expanded') === hasAttribute) {
+                                resolve();
+                            } else {
+                                check();
+                            }
+                        }, 500);
+                    };
+                    check();
+                });
+            }, hasAttribute);
+        };
 
         await fulfillJson(
             page,
@@ -430,18 +446,7 @@ test.beforeEach(noCacheRoute);
 
         // Close the sidebar
         await page.locator(SELECTORS.SIDEBAR_HA_ICON_BUTTON).click();
-        await sidebar.evaluate((sidebarElement: HTMLElement) => {
-            return new Promise<void>((resolve) => {
-                const check = () => {
-                    if (sidebarElement.hasAttribute('expanded') === false) {
-                        resolve();
-                    } else {
-                        setTimeout(check, 500);
-                    }
-                };
-                check();
-            });
-        });
+        await checkExpanded(false);
         sidebarWidth = await getSidebarWidth(page, false);
         expect(sidebarWidth).not.toBe(width);
 
@@ -459,24 +464,13 @@ test.beforeEach(noCacheRoute);
         await page.reload();
         await waitForMainElements(page);
         await expect(page.locator(SELECTORS.HUI_VIEW)).toBeVisible();
-        await expect(page.locator(SELECTORS.HA_SIDEBAR)).not.toHaveAttribute('expanded');
+        await checkExpanded(false);
         sidebarWidth = await getSidebarWidth(page, true);
         expect(sidebarWidth).not.toBe(width);
 
         // Open the sidebar again
         await page.locator(SELECTORS.SIDEBAR_HA_ICON_BUTTON).click();
-        await sidebar.evaluate((sidebarElement: HTMLElement) => {
-            return new Promise<void>((resolve) => {
-                const check = () => {
-                    if (sidebarElement.hasAttribute('expanded') === true) {
-                        resolve();
-                    } else {
-                        setTimeout(check, 500);
-                    }
-                };
-                check();
-            });
-        });
+        await checkExpanded(true);
         sidebarWidth = await getSidebarWidth(page, false);
         expect(sidebarWidth).toBe(width);
     });


### PR DESCRIPTION
This pull request moves the check for the `expanded` attribute to a utility function in the test `should set sidebar width.hidden and sidebar.extended and keep them when the sidebar is not extended`.