### PR TITLE
Add a note to the Configuration file section in the documentation

### DIFF
--- a/docs/docs/03-configuration/01-configuration-file.mdx
+++ b/docs/docs/03-configuration/01-configuration-file.mdx
@@ -4,7 +4,13 @@ sidebar_position: 1
 
 # Configuration File
 
-Add a file named `custom-sidebar-config.yaml` into your `<config directory>/www/` directory. It is recommendable that you copy the [example custom-sidebar-config.yaml] file, delete the `id` parameter, and modify it to match your needs. Begin with the simplest configuration and start to extend it step by step, in that way if you suffer any issue, it is easy to identify with which code block it started.
+Add a file named `custom-sidebar-config.yaml` into your `<config directory>/www/` directory. It is recommendable that you copy the [example custom-sidebar-config.yaml] file and modify it to match your needs. Begin with the simplest configuration and start to extend it step by step, in that way if you suffer any issue, it is easy to identify with which code block it started.
+
+:::info
+
+Delete or edit the `id` parameter of the example configuration. It is there just to detect if you have not edited the example configuration.
+
+:::
 
 :::tip
 


### PR DESCRIPTION
This pull request adds an info banner in the `Configuration file` section of the documentation. It has an extended text to explain why one needs to remove or edit the `id` parameter from the example configuration.