### PR TITLE
Move previous Home Assistant versions installation warnings into details

### DIFF
--- a/docs/docs/02-installation.mdx
+++ b/docs/docs/02-installation.mdx
@@ -9,16 +9,27 @@ import InstallationManualExample from '@site/docs/_partials/02-installation/_ins
 
 :::warning[Important]
 
+If you have `Home Assistant` `2026.6.0` or greater installed, the minimum compatible version that you can install is `Custom Sidebar` `v15.0.0`. If you are in a `Home Assistant` version between `2026.5.0` and `2026.6.0`, the latest compatible version that you can install is `v14.2.0`.
+
+<details
+    style={{
+        '--ifm-alert-background-color': 'transparent',
+        '--ifm-alert-border-color': 'var(--ifm-color-warning-dark)',
+        '--ifm-code-background': 'rgba(255, 186, 0, 0.15)'
+    }}
+>
+  <summary>Previous Home Assistant versions</summary>
+
 * If you have `Home Assistant` `2026.2.0` or greater installed, the minimum compatible version that you can install is `Custom Sidebar` `v12.0.0`. If you are in a `Home Assistant` version between `2025.5.0` and `2026.1.3`, the latest compatible version that you can install is `v11.2.0`.
 * If you have `Home Assistant` `2026.3.0` or greater installed, the minimum compatible version that you can install is `Custom Sidebar` `v13.0.0`. If you are in a `Home Assistant` version between `2026.1.3` and `2026.2.3`, the latest compatible version that you can install is `v12.1.1`.
 * If you have `Home Assistant` `2026.5.0` or greater installed, the minimum compatible version that you can install is `Custom Sidebar` `v14.0.0`. If you are in a `Home Assistant` version between `2026.2.3` and `2026.4.4`, the latest compatible version that you can install is `v13.1.0`.
-* If you have `Home Assistant` `2026.6.0` or greater installed, the minimum compatible version that you can install is `Custom Sidebar` `v15.0.0`. If you are in a `Home Assistant` version between `2026.5.0` and `2026.6.0`, the latest compatible version that you can install is `v14.2.0`.
+</details>
 
 :::
 
 You can install the plugin manually or through [HACS], not both. **If you install the plugin using the two installations methods you could have issues or errors**.
 
-### Through HACS (recommended)
+### Installation through HACS (recommended)
 
 #### Go to the HACS plugin's page
 


### PR DESCRIPTION
This mere request moves the warnings about previous Home Assistant versions into a markdown detail block.