### PR TITLE
Improve Troubleshooting section intro

### DIFF
--- a/docs/docs/08-troubleshooting/01-customisations-are-not-applied.mdx
+++ b/docs/docs/08-troubleshooting/01-customisations-are-not-applied.mdx
@@ -10,7 +10,7 @@ If the customisations are applied correctly in a browser but not in the Companio
 
 :::
 
-1. First of all, open Home Assistant in your browser and check in the console tab of the Developer tools of your browser that the Custom Sidebar `console.info` is there:
+1. First of all, open Home Assistant in your browser and check in the console tab of the Developer tools of your browser that the Custom Sidebar `console.info` is there with the correct version that you have installed:
 
 ![Custom Sidebar console.info](@site/docs/_images/08-troubleshooting/01-customisations-are-not-applied/custom-sidebar-console-info.png)
 

--- a/docs/docs/08-troubleshooting/03-customisations-are-not-applied-in-all-devices.mdx
+++ b/docs/docs/08-troubleshooting/03-customisations-are-not-applied-in-all-devices.mdx
@@ -1,0 +1,11 @@
+---
+sidebar_position: 3
+---
+
+# Customisations are not applied in all devices
+
+If the sidebar customisations work perfectly when you are connected through your local network but they don't work when you are connected remotely, or if you see that they work in some of your devices and not in others, you are suffering from caching issues. Caching is not something that is performed only in your device. Caching is performed at any level: in your local network, proxies, DNS providers (as Cloudflare), internet providers, Nabucasa, etc. You need to identify from which place the cache is performed and clean it there.
+
+First thing to make sure is that the cache is not coming from your device. If you are in a browser, open the developer console, go to the `Network` tab and check the checkbox labeled as `Disable cache`, refresh the browser multiple times with the developer console open and then check if the caching issues are solved. If the issue is only in the Companion App, consult [Issues with the Companion App](./issues-with-the-companion-app).
+
+If the caching issues don't go away, most of the time you can solve them uninstalling `custom-sidebar` entirely (you don't need to remove the configuration), remove the path to `custom-sidebar-plugin.js` in the `frontend > extra_module_url` entry in your configuration and restart `Home Assistant`. After restarting and checking that there is no any trace of `custom-sidebar`, then install the plugin again following [the installation instructions](../02-installation.mdx).

--- a/docs/docs/08-troubleshooting/03-customisations-are-not-applied-remotely.mdx
+++ b/docs/docs/08-troubleshooting/03-customisations-are-not-applied-remotely.mdx
@@ -1,7 +1,0 @@
----
-sidebar_position: 3
----
-
-# Customisations are not applied remotely
-
-If the sidebar customisations work perfectly when you are connected through your local network but they don't work when you are connected remotely, most probably you are suffering from caching issues. If you are in a browser, open the developer console, go to `Network` and check the checkbox labeled as `Disable cache`, refresh the browser with the developer console open. If the issue is only in the Companion App, consult [Issues with the Companion App](./issues-with-the-companion-app).

--- a/docs/docs/08-troubleshooting/_category_.yaml
+++ b/docs/docs/08-troubleshooting/_category_.yaml
@@ -1,4 +1,0 @@
-label: Troubleshooting
-position: 8
-link:
-  type: generated-index

--- a/docs/docs/08-troubleshooting/index.mdx
+++ b/docs/docs/08-troubleshooting/index.mdx
@@ -1,0 +1,20 @@
+---
+sidebar_position: 8
+---
+
+import DocCardList from '@theme/DocCardList';
+
+# Troubleshooting
+
+This plugin counts [with an extensive suite of end-to-end tests](https://github.com/elchininet/custom-sidebar/tree/b080083376cca657bf06d740d3dc30d4fa7c2b32/tests). At the moment of writing, there are 466 tests covering every single option of the plugin and the coverage of the code [is at 100%](https://coveralls.io/github/elchininet/custom-sidebar?branch=master). On top of this, there are also [regression tests through screenshots](https://github.com/elchininet/custom-sidebar/tree/b080083376cca657bf06d740d3dc30d4fa7c2b32/test-snapshots) to check that that there are no visual changes when a modification of the code is done. There are also [Nightly Beta Tests](https://github.com/elchininet/custom-sidebar/actions/workflows/ha-beta-tests.yaml) in place that run every night against the [homeassistant/home-assistant:beta tag](https://hub.docker.com/layers/homeassistant/home-assistant/beta/images/) that allows us to detect if any option of the plugin will be broken in the next `Home Assistant` version before that version is released.
+
+This means that if you detect that your configuration stopped working suddenly after an update, there are four possible reasons for that:
+
+1. The first one is caching
+2. The second one is caching
+3. The third one is caching
+4. The fourth one could be a bug in the code
+
+Due to the amount of [invalid issues](https://github.com/elchininet/custom-sidebar/issues?q=is%3Aissue%20state%3Aclosed%20label%3Ainvalid) in the repo (the majority related to caching issues), the Troubleshooting section has been created to help you detect from which place are coming your issues taking into account the most common causes. So first follow this section before assuming that there is a bug in the plugin code and reporting an issue.
+
+<DocCardList />


### PR DESCRIPTION
Almost all the invalid issues in the repo are relating to caching issues. Users ignore that the repo has an extensive suit of end-to-ed tests and that every option of the plugin is tested every day against the beta version of `Home Assistant`. For this reason, it would be good to create an introduction in [the Troubleshooting section](https://elchininet.github.io/custom-sidebar/category/troubleshooting) to encourage users to follow the Troubleshooting before reporting an issue.